### PR TITLE
Feature/pillar

### DIFF
--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -55,6 +55,7 @@ module Kitchen
       default_config :salt_run_highstate, true
       default_config :salt_copy_filter, []
       default_config :is_file_root, false
+      default_config :pillar_root, false
 
       default_config :dependencies, []
       default_config :vendor_path, ""
@@ -297,6 +298,7 @@ module Kitchen
         return if config[:pillars].nil? && config[:'pillars-from-files'].nil?
 
 
+        return if config[:pillars].nil? && config[:'pillars-from-files'].nil? && config[:pillar_root] == false
 
         # we get a hash with all the keys converted to symbols, salt doesn't like this
         # to convert all the keys back to strings again
@@ -340,6 +342,15 @@ module Kitchen
             FileUtils.copy srcfile, sandbox_pillar_path
           end
         end
+
+        # Copy directory of pillar data
+        if config[:pillar_root]
+          debug("Using pillars from #{config[:pillar_root]}")
+          sandbox_pillar_path = File.join(sandbox_path, config[:salt_pillar_root])
+          FileUtils.mkdir_p(File.dirname(sandbox_pillar_path))
+          FileUtils.cp_r(File.join(config[:pillar_root], '/'), sandbox_pillar_path)
+        end
+
       end
 
       def prepare_grains

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -25,6 +25,7 @@ state_collection | false | treat this directory as a salt state collection and n
 [collection_name](#collection_name) | | used to derive then name of states we want to apply in a state collection. (if collection_name isn't set, formula will be used)
 [pillars](#pillars)| {} | pillar data
 [pillars-from-files](#pillars-from-files) | | a list of key-value pairs for files that should be loaded as pillar data
+pillar_root| | directory containing pillar data
 [grains](#grains) | | a hash to be re-written as /etc/salt/grains on the guest
 [dependancies](#dependancies) | | a list of hashes specifying dependancies formulas to be copied into the VM. e.g. [{ :path => 'deps/icinga-formula', :name => 'icinga' }]
 
@@ -258,7 +259,16 @@ And the contents of pillar.example is a normal pillar file:
 	  transport: stdout
 	  format: json
 
+### [pillar_root](id:pillar_root)
+Directory of pillar data and pillar topfile for local evaluation.
 
+i.e.
+
+    provisioner:
+      name: salt_solo
+      pillar_root: ../pillar
+      is_file_root: true
+          
 
 ### [grains](id:grains)
 (since v0.0.15)


### PR DESCRIPTION
This PR is meant to be a request for feedback rather than something that's immediately ready to merge.

In my environment, we have a single repository for all our salt formula and pillar data. We run masterless, so all the pillar data is evaluated in the minions (there are no secrets stored there).

What I'd like to do is to be able to create multiple scenarios where I set the values of some grains (mostly to define the role of a system) and then run a highstate with all the states we use, and then run tests against the resulting config.

So I want to use an entire state tree and topfile for that state tree, which is already supported, but also use my entire pillar tree and topfile for that tree. That's what this PR (starts to) provide support for, by:
- Creating new pillar_root config option, which specifies the local source of the pillar tree & topfile for sending to the VMs
- Changing the way the pillars option is processed, generating a single YAML file with all the pillar values
- Evaluating the pillar values set by the pillars option using an ext_pillar in the salt minion config

Changing the way the pillars option in this way allows the user to manually overwrite an evaluated pillar value with their defined value.

Based on this I think it would be good to create a `file_root` option for specifying where to look for the state data and top file. That functionality is pretty similar to the `is_file_root` option, but that option as it stands doesn't give you much flexibility. Perhaps it would be possible to continue to support `is_file_root,` but make it set `file_root` to the base source directory?

I can make those changes, but I wanted to put them to you for feedback before taking this too much further.
