### PR TITLE
Fix the spelling of dependencies

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,6 +1,6 @@
 v0.0.19
 * Added ability to copy additional dependency formulas into the VM
-  See https://github.com/simonmcc/kitchen-salt/blob/master/provisioner_options.md#dependancies
+  See https://github.com/simonmcc/kitchen-salt/blob/master/provisioner_options.md#dependencies
 
 v0.0.18
 * Added ability to filter paths from the set of files copied to the guest

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -26,7 +26,7 @@ state_collection | false | treat this directory as a salt state collection and n
 [pillars](#pillars)| {} | pillar data
 [pillars-from-files](#pillars-from-files) | | a list of key-value pairs for files that should be loaded as pillar data
 [grains](#grains) | | a hash to be re-written as /etc/salt/grains on the guest
-[dependancies](#dependancies) | | a list of hashes specifying dependancies formulas to be copied into the VM. e.g. [{ :path => 'deps/icinga-formula', :name => 'icinga' }]
+[dependencies](#dependencies) | | a list of hashes specifying dependencies formulas to be copied into the VM. e.g. [{ :path => 'deps/icinga-formula', :name => 'icinga' }]
 
 
 ##Configuring Provisioner Options


### PR DESCRIPTION
I also noticed that the latest gem release still uses the old dependancies config?
Could you push a new version to rubygems?
