### PR TITLE
fix erro when "salt_run_highstate" is not set. Run salt-call but not

### DIFF
--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -188,6 +188,8 @@ module Kitchen
         debug(diagnose())
         if config[:salt_run_highstate]
           cmd = sudo("salt-call --config-dir=#{File.join(config[:root_path], config[:salt_config])} --local state.highstate")
+        else
+          cmd = sudo("salt-call state.highstate")
         end
 
         cmd << " --log-level=#{config[:log_level]}"


### PR DESCRIPTION
…local

I install salt via bootstrap-script and the -A option to set the salt-master. Now I want to kitchen-test a client using a "normal" salt-call
