### PR TITLE
Allow overriding the top.sls per suite.

### DIFF
--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -153,7 +153,6 @@ module Kitchen
         super
         prepare_data
         prepare_minion
-        prepare_state_top
         prepare_pillars
         prepare_grains
 
@@ -183,6 +182,7 @@ module Kitchen
             prepare_formula formula[:path], formula[:name]
           end
         end
+        prepare_state_top
       end
 
       def init_command


### PR DESCRIPTION
I found that while trying to test individual suites from our repo, that the `state_top` was clobbered due to ordering, when using `is_file_root: true`. This pull request re-orders the `prepare_*` statements so that the `state_top` is last.

The following is an example of a `.kitchen.yml` using different `state_top` values:

```

---
driver:
  ...

transport:
  ...

platforms:
  - name: ubuntu-15.04
    driver:
      image_id: ami-b3fbccc4

provisioner:
  require_chef_omnibus: true
  chef_omnibus_url: https://www.chef.io/chef/install.sh
  salt_bootstrap_options: -P git v2015.8.1
  name: salt_solo
  is_file_root: true

suites:
  - name: default

  - name: base
    provisioner:
      state_top_from_file: false
      state_top:
        base:
          '*':
            - base
      pillars-from-files:
        base.sls: test/pillar/base.sls
      pillars:
        top.sls:
          base:
            '*':
              - base

 - name: monitoring
    provisioner:
      state_top_from_file: false
      pillars-from-files:
        base.sls: test/pillar/base.sls
      pillars:
        top.sls:
          base:
            '*':
              - base
              - monitoring
      state_top:
        base:
          '*':
            - base
            - monitoring

```
