### PR TITLE
add ppa support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ tmp
 .yardoc
 _yardoc
 doc/
+
+# Other
+*.DS_Store

--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -41,6 +41,7 @@ module Kitchen
       # alternative method of installing salt
       default_config :salt_apt_repo, "http://apt.mccartney.ie"
       default_config :salt_apt_repo_key, "http://apt.mccartney.ie/KEY"
+      default_config :salt_ppa, "ppa:saltstack/salt"
 
       default_config :chef_bootstrap_url, "https://www.getchef.com/chef/install.sh"
 
@@ -82,6 +83,7 @@ module Kitchen
         salt_version = config[:salt_version]
         salt_apt_repo = config[:salt_apt_repo]
         salt_apt_repo_key = config[:salt_apt_repo_key]
+        salt_ppa = config[:salt_ppa]
 
         omnibus_download_dir = config[:omnibus_cachier] ? "/tmp/vagrant-cache/omnibus_chef" : "/tmp"
 
@@ -108,6 +110,11 @@ module Kitchen
 
             #{sudo('apt-get')} update
             #{sudo('apt-get')} install -y salt-minion
+          elif [ -z "${SALT_VERSION}" -a "#{salt_install}" = "ppa" ]
+          then
+            #{sudo('apt-add-repository')} -y #{salt_ppa}
+            #{sudo('apt-get')} update
+            #{sudo('apt-get')} install -y salt-minion
           fi
 
           # check again, now that an install of some form should have happened
@@ -122,6 +129,7 @@ module Kitchen
             echo "salt_version = #{salt_version}"
             echo "salt_apt_repo = #{salt_apt_repo}"
             echo "salt_apt_repo_key = #{salt_apt_repo_key}"
+            echo "salt_ppa = #{salt_ppa}"
             exit 2
           elif [ "${SALT_VERSION}" = "#{salt_version}" -o "#{salt_version}" = "latest" ]
           then

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -5,12 +5,13 @@ key | default value | Notes
 ----|---------------|--------
 formula | | name of the formula, used to derive the path we need to copy to the guest
 [is_file_root](#is_file_root) | false | Treat this project as a complete file_root, not just a state collection or formula
-salt_install| "bootstrap" | Method by which to install salt, "bootstrap" or "apt"
+salt_install| "bootstrap" | Method by which to install salt, "bootstrap", "apt" or "ppa"
 salt_bootstrap_url | "http://bootstrap.saltstack.org" | location of bootstrap script
 [salt_bootstrap_options](#salt_bootstrap_options) | | optional options passed to the salt bootstrap script
 salt_version | "0.16.2"| desired version, only affects apt installs
 salt_apt_repo | "http://apt.mccartney.ie"| apt repo
 salt_apt_repo_key| "http://apt.mccartney.ie/KEY"| apt repo key
+salt_ppa | "ppa:saltstack/salt" | Official Ubuntu SaltStack PPA
 chef_bootstrap_url| "https://www.getchef.com/chef/install.sh"| the chef bootstrap installer, used to provide Ruby for the serverspec test runner on the guest OS
 salt_config| "/etc/salt"|
 [salt_copy_filter](#salt_copy_filter) | [] | List of filenames to be excluded when copying states, formula & pillar data down to guest instances.
@@ -153,6 +154,9 @@ Version of salt to install, via the git bootstrap method, unless ```salt_install
 
 ### [salt_apt_repo](id:salt_apt_repo) 
 ### [salt_apt_repo_key](id:salt_apt_repo_key)
+### [ salt_ppa](id:salt_ppa)
+Adds the supplied PPA. The default being the Official SaltStack PPA. Useful when the release (e.g. vivid) does not have support via the standard boostrap script or apt repo.
+
 ### [chef_bootstrap_url](id:chef_bootstrap_url)
 ### [salt_config](id:salt_config)
 ### [salt_minion_config](id:salt_minion_config)


### PR DESCRIPTION
Currently, the salt repos and bootstrap script don't have support for vivid -- However, they do have deb's built and available in the official saltstack PPA.  This PR adds `salt_ppa` to the provisioner options and will default to using it if `salt_install` is set to `ppa`.
