### PR TITLE
Adding windows platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ A Test Kitchen Provisioner for Salt
 
 The provider works by generating a salt-minion config, creating pillars based on attributes in .kitchen.yml & calling salt-call.
 
-This provider has been tested against the Ubuntu boxes running in vagrant/virtualbox & vagrant-lxc boxes on Ubuntu.
+This provider has been tested against:
+- Linux (Ubuntu)
+  - vagrant/virtualbox
+  - vagrant-lxc
+- Windows
+  - 2012R2
 
 ## Installation & Setup
 You'll need the test-kitchen & kitchen-salt gem's installed in your system, along with kitchen-vagrant or some ther suitable driver for test-kitchen.  Please see the [INTRODUCTION](https://github.com/simonmcc/kitchen-salt/blob/master/INTRODUCTION.md).
@@ -22,12 +27,11 @@ Catching salt failures is particularly troublesome, as salt & salt-call don't do
 code to something useful, around ~0.17.5, the `--retcode-passthrough` option was added, but even in 2014.1.0 this is
 still flawed, [PR11337](https://github.com/saltstack/salt/pull/11337) should help fix some of those problems.  In the
 mean time, we scan the salt-call output for signs of failure (essentially `grep -e Result.*False -e Data.failed.to.compile -e
-No.matching.sls.found.for`) and check for a
-non-zero exit code from salt-call.
+No.matching.sls.found.for`) and check for a non-zero exit code from salt-call. 
 
 
 ## Requirements
-You'll need a driver box that is supported by both the SaltStack [bootstrap](https://github.com/saltstack/salt-bootstrap) system & the Chef Omnibus installer (the Chef Omnibus installer is only needed to provide busser with a useable ruby environment, you can tell busser to use an alternative ruby if your box has suitable ruby support built in).
+You'll need a driver box supported by both the SaltStack [bootstrap](https://github.com/saltstack/salt-bootstrap) system & the Chef Omnibus installer (the Chef Omnibus installer is only needed to provide busser with a useable ruby environment, you can tell busser to use an alternative ruby if your box has suitable ruby support built in).
 
 ## Releasing
 

--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -30,26 +30,17 @@ module Kitchen
     # @author Chris Lundquist (<chris.ludnquist@github.com>)
     class SaltSolo < Base
 
+      # platform independent variables
       default_config :salt_version, "latest"
 
       # supported install methods: bootstrap|apt
       default_config :salt_install, "bootstrap"
-
-      default_config :salt_bootstrap_url, "http://bootstrap.saltstack.org"
-      default_config :salt_bootstrap_options, ""
 
       # alternative method of installing salt
       default_config :salt_apt_repo, "http://apt.mccartney.ie"
       default_config :salt_apt_repo_key, "http://apt.mccartney.ie/KEY"
       default_config :salt_ppa, "ppa:saltstack/salt"
 
-      default_config :chef_bootstrap_url, "https://www.getchef.com/chef/install.sh"
-
-      default_config :salt_config, "/etc/salt"
-      default_config :salt_minion_config, "/etc/salt/minion"
-      default_config :salt_file_root, "/srv/salt"
-      default_config :salt_pillar_root, "/srv/pillar"
-      default_config :salt_state_top, "/srv/salt/top.sls"
       default_config :state_collection, false
       default_config :state_top, {}
       default_config :state_top_from_file, false
@@ -61,6 +52,45 @@ module Kitchen
       default_config :vendor_path, nil
       default_config :omnibus_cachier, false
 
+      # platform specific variables
+      # Not working on windows yet
+      default_config :require_chef_omnibus do |provisioner|
+        provisioner.windows_os? ? false : true
+      end
+
+	  # This needs more logic before it works for windows
+      default_config :salt_bootstrap_options do |provisioner|
+        provisioner.windows_os? ? "" : ""
+      end
+
+      default_config :salt_bootstrap_url do |provisioner|
+        provisioner.windows_os? ? "http://boohttps://raw.githubusercontent.com/saltstack/salt-bootstrap/develop/bootstrap-salt.ps1" : "http://bootstrap.saltstack.org"
+      end
+      
+      default_config :chef_bootstrap_url do |provisioner|
+        provisioner.windows_os? ? "https://opscode-omnibus-packages.s3.amazonaws.com/windows/2012r2/i386/chef-client-12.7.2-1-x86.msi" : "https://www.getchef.com/chef/install.sh"
+      end
+      
+      default_config :salt_config do |provisioner|
+        provisioner.windows_os? ? "c/salt/conf" : "/etc/salt"
+      end
+      
+      default_config :salt_minion_config do |provisioner|
+        provisioner.windows_os? ? "c/salt/conf/minion" : "/etc/salt/minion"
+      end
+            
+      default_config :salt_file_root do |provisioner|
+        provisioner.windows_os? ? "c/srv/salt" : "/srv/salt"
+      end
+      
+      default_config :salt_pillar_root do |provisioner|
+        provisioner.windows_os? ? "c/srv/salt/pillar" : "/srv/salt/pillar"
+      end
+      
+      default_config :salt_state_top do |provisioner|
+        provisioner.windows_os? ? "c/srv/salt/state/top.sls" : "/srv/salt/top.sls"
+      end
+
       # salt-call version that supports the undocumented --retcode-passthrough command
       RETCODE_VERSION = '0.17.5'
 
@@ -69,12 +99,14 @@ module Kitchen
 
         # if salt_verison is set, bootstrap is being used & bootstrap_options is empty,
         # set the bootstrap_options string to git install the requested version
+        ### This needs more logic before it works for windows ###
         if ((config[:salt_version] != 'latest') && (config[:salt_install] == 'bootstrap') && config[:salt_bootstrap_options].empty?)
           debug("Using bootstrap git to install #{config[:salt_version]}")
           config[:salt_bootstrap_options] = "-P git v#{config[:salt_version]}"
         end
 
         salt_install = config[:salt_install]
+        chef_omnibus = config[:require_chef_omnibus]
 
         salt_url = config[:salt_bootstrap_url]
         chef_url = config[:chef_bootstrap_url]
@@ -85,76 +117,112 @@ module Kitchen
         salt_apt_repo_key = config[:salt_apt_repo_key]
         salt_ppa = config[:salt_ppa]
 
+        # Not working on windows yet
         omnibus_download_dir = config[:omnibus_cachier] ? "/tmp/vagrant-cache/omnibus_chef" : "/tmp"
 
-        <<-INSTALL
-          sh -c '
-          #{Util.shell_helpers}
+        if windows_os?
+          info("Installing salt minion and chefdk for testing")
+            
+          <<-POWERSHELL
+          # Bootstrap script
+          if (Test-Path $env:ProgramData\\Chocolatey){
+            choco list boxstarter.chocolatey
+          }
+          else{
+            Write-Host "Chocolatey will be installed."
+            iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+          }
+            
+          # Check if Salt Minion is installed
+          if (Test-Path C:/Salt){
+            choco list saltminion    
+          }
+          else{
+            choco install saltminion -r -y
+          }
+                        
+          if (Test-Path C:/opscode/chefdk){
+            choco list chefdk   
+          }
+          elseif($#{chef_omnibus}){
+            choco install chefdk -r -y 
+          }
+          else{
+            Write-Host "Skipping install of ChefDK because 'require_chef_omnibus' is set to #{chef_omnibus}."
+          }
+          POWERSHELL
+              
+        else
 
-          # what version of salt is installed?
-          SALT_VERSION=`salt-call --version | cut -d " " -f 2`
+          <<-INSTALL
+            sh -c '
+            #{Util.shell_helpers}
+
+            # what version of salt is installed?
+            SALT_VERSION=`salt-call --version | cut -d " " -f 2`
 
 
-          if [ -z "${SALT_VERSION}" -a "#{salt_install}" = "bootstrap" ]
-          then
-            do_download #{salt_url} /tmp/bootstrap-salt.sh
-            #{sudo('sh')} /tmp/bootstrap-salt.sh #{bootstrap_options}
-          elif [ -z "${SALT_VERSION}" -a "#{salt_install}" = "apt" ]
-          then
-            . /etc/lsb-release
-
-            echo "deb #{salt_apt_repo}/salt-#{salt_version} ${DISTRIB_CODENAME} main" | #{sudo('tee')} /etc/apt/sources.list.d/salt-#{salt_version}.list
-
-            do_download #{salt_apt_repo_key} /tmp/repo.key
-            #{sudo('apt-key')} add /tmp/repo.key
-
-            #{sudo('apt-get')} update
-            #{sudo('apt-get')} install -y salt-minion
-          elif [ -z "${SALT_VERSION}" -a "#{salt_install}" = "ppa" ]
-          then
-            #{sudo('apt-add-repository')} -y #{salt_ppa}
-            #{sudo('apt-get')} update
-            #{sudo('apt-get')} install -y salt-minion
-          fi
-
-          # check again, now that an install of some form should have happened
-          SALT_VERSION=`salt-call --version | cut -d " " -f 2`
-
-          if [ -z "${SALT_VERSION}" ]
-          then
-            echo "No salt-minion installed, install must have failed!!"
-            echo "salt_install = #{salt_install}"
-            echo "salt_url = #{salt_url}"
-            echo "bootstrap_options = #{bootstrap_options}"
-            echo "salt_version = #{salt_version}"
-            echo "salt_apt_repo = #{salt_apt_repo}"
-            echo "salt_apt_repo_key = #{salt_apt_repo_key}"
-            echo "salt_ppa = #{salt_ppa}"
-            exit 2
-          elif [ "${SALT_VERSION}" = "#{salt_version}" -o "#{salt_version}" = "latest" ]
-          then
-            echo "You asked for #{salt_version} and you have ${SALT_VERSION} installed, sweet!"
-          elif [ ! -z "${SALT_VERSION}" -a "#{salt_install}" = "bootstrap" ]
-          then
-            echo "You asked for bootstrap install and you have got ${SALT_VERSION}, hope thats ok!"
-          else
-            echo "You asked for #{salt_version} and you have got ${SALT_VERSION} installed, dunno how to fix that, sorry!"
-            exit 2
-          fi
-
-          if [ ! -d "/opt/chef" ]
-          then
-            echo "-----> Installing Chef Omnibus"
-            mkdir -p #{omnibus_download_dir}
-            if [ ! -x #{omnibus_download_dir}/install.sh ]
+            if [ -z "${SALT_VERSION}" -a "#{salt_install}" = "bootstrap" ]
             then
-              do_download #{chef_url} #{omnibus_download_dir}/install.sh
-            fi
-            #{sudo('sh')} #{omnibus_download_dir}/install.sh -d #{omnibus_download_dir}
-          fi
+              do_download #{salt_url} /tmp/bootstrap-salt.sh
+              #{sudo('sh')} /tmp/bootstrap-salt.sh #{bootstrap_options}
+            elif [ -z "${SALT_VERSION}" -a "#{salt_install}" = "apt" ]
+            then
+              . /etc/lsb-release
 
-          '
-        INSTALL
+              echo "deb #{salt_apt_repo}/salt-#{salt_version} ${DISTRIB_CODENAME} main" | #{sudo('tee')} /etc/apt/sources.list.d/salt-#{salt_version}.list
+
+              do_download #{salt_apt_repo_key} /tmp/repo.key
+              #{sudo('apt-key')} add /tmp/repo.key
+
+              #{sudo('apt-get')} update
+              #{sudo('apt-get')} install -y salt-minion
+            elif [ -z "${SALT_VERSION}" -a "#{salt_install}" = "ppa" ]
+            then
+              #{sudo('apt-add-repository')} -y #{salt_ppa}
+              #{sudo('apt-get')} update
+              #{sudo('apt-get')} install -y salt-minion
+            fi
+
+            # check again, now that an install of some form should have happened
+            SALT_VERSION=`salt-call --version | cut -d " " -f 2`
+
+            if [ -z "${SALT_VERSION}" ]
+            then
+              echo "No salt-minion installed, install must have failed!!"
+              echo "salt_install = #{salt_install}"
+              echo "salt_url = #{salt_url}"
+              echo "bootstrap_options = #{bootstrap_options}"
+              echo "salt_version = #{salt_version}"
+              echo "salt_apt_repo = #{salt_apt_repo}"
+              echo "salt_apt_repo_key = #{salt_apt_repo_key}"
+              echo "salt_ppa = #{salt_ppa}"
+              exit 2
+            elif [ "${SALT_VERSION}" = "#{salt_version}" -o "#{salt_version}" = "latest" ]
+            then
+              echo "You asked for #{salt_version} and you have ${SALT_VERSION} installed, sweet!"
+            elif [ ! -z "${SALT_VERSION}" -a "#{salt_install}" = "bootstrap" ]
+            then
+              echo "You asked for bootstrap install and you have got ${SALT_VERSION}, hope thats ok!"
+            else
+              echo "You asked for #{salt_version} and you have got ${SALT_VERSION} installed, dunno how to fix that, sorry!"
+              exit 2
+            fi
+
+            if [ ! -d "/opt/chef" ]
+            then
+              echo "-----> Installing Chef Omnibus"
+              mkdir -p #{omnibus_download_dir}
+              if [ ! -x #{omnibus_download_dir}/install.sh ]
+              then
+                do_download #{chef_url} #{omnibus_download_dir}/install.sh
+              fi
+              #{sudo('sh')} #{omnibus_download_dir}/install.sh -d #{omnibus_download_dir}
+            fi
+
+            '
+          INSTALL
+        end
       end
 
       def create_sandbox
@@ -194,8 +262,14 @@ module Kitchen
       end
 
       def init_command
-        debug("Initialising Driver #{self.name} by cleaning #{config[:root_path]}")
-        "#{sudo('rm')} -rf #{config[:root_path]} ; mkdir -p #{config[:root_path]}"
+        info("Initialising Driver #{self.name} by cleaning #{config[:root_path]}")
+        # Reset upload path permissions for the current ssh user
+        if windows_os?
+            @machine.communicate.sudo("rm ""#{config.upload_path}"" -Recurse -Force;mkdir -Path ""#{config.upload_path}""")
+        else
+            @machine.communicate.sudo("mkdir -p #{config.upload_path}")
+            @machine.communicate.sudo("chown -R #{user} #{config.upload_path}")
+        end
       end
 
       def run_command


### PR DESCRIPTION
This is the first of a couple PRs for windows support. Currently this will update the documentation and enabling this provisioner to spin up a windows server, install chocolatey (package mgmt), and install a salt minion (via chocolatey). I also enables installing chefDK via chocolatey too, but has this turned off by default since it fails. This issue will be created since I can't determine where it's failing exactly. What it can to is use an existing busser for windows, pester, for testing. This needs to be added to the [beaver formula](https://github.com/simonmcc/beaver-formula) via PR. [Pester](https://github.com/test-kitchen/kitchen-pester) has more information here. I'm hoping this wil cause a new version of the gem to be created so others can start experimenting/building on the windows support.
