### PR TITLE
kitchen-salt breaks with test-kitchen 1.7.0 (invalid --log-level in salt-call)

### DIFF
--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -206,7 +206,9 @@ module Kitchen
           cmd = sudo("salt-call --config-dir=#{File.join(config[:root_path], config[:salt_config])} --local state.highstate")
         end
 
-        cmd << " --log-level=#{config[:log_level]}"
+        if config[:log_level]
+          cmd << " --log-level=#{config[:log_level]}"
+        end
 
         # config[:salt_version] can be 'latest' or 'x.y.z', 'YYYY.M.x' etc
         # error return codes are a mess in salt:


### PR DESCRIPTION
With test-kitchen 1.7.0 the log_level config is not copied into the provisioner settings anymore. See pull request test-kitchen/test-kitchen#950.

As a result the following error would be displayed on a `kitchen converge` call:

```
salt-call: error: option --log-level: invalid choice: '' (choose from 'info', 'profile', 'all', 'critical', 'trace', 'garbage', 'error', 'debug', 'warning', 'quiet')
```

This pull requests appends the `--log-level` option only if it was explicitly specified (e.g. in .kitchen.yml).
