### PR TITLE
fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: ruby
+
 rvm:
-  - 1.9.3
-  - 2.1.5
+  - 2.1.8
+  - 2.2.4
+  - ruby-head
+
 script: bundle exec rspec
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head


### PR DESCRIPTION
The current net-ssh gem (3.1.1) no longer supports ruby 1.9.3. The test-kitchen travis build only tests against 2.1, 2.2 and ruby-head. This pull request adjusts .travis.yml to the same versions used by test-kitchen.
