### PR TITLE
Fix logic around error detection

### DIFF
--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -221,21 +221,21 @@ module Kitchen
         #  https://github.com/saltstack/salt/pull/11337
         # Unless we know we have a version that supports --retcode-passthrough
         # attempt to scan the output for signs of failure
-        if config[:salt_version] > RETCODE_VERSION && config[:salt_version] != 'latest'
+        if config[:salt_version] > RETCODE_VERSION || config[:salt_version] == 'latest'
           # hope for the best and hope it works eventually
           cmd = cmd + " --retcode-passthrough"
+        else
+          # scan the output for signs of failure, there is a risk of false negatives
+          fail_grep = 'grep -e Result.*False -e Data.failed.to.compile -e No.matching.sls.found.for'
+          # capture any non-zero exit codes from the salt-call | tee pipe
+          cmd = 'set -o pipefail ; ' << cmd
+          # Capture the salt-call output & exit code
+          cmd << " 2>&1 | tee /tmp/salt-call-output ; SC=$? ; echo salt-call exit code: $SC ;"
+          # check the salt-call output for fail messages
+          cmd << " (sed '/#{fail_grep}/d' /tmp/salt-call-output | #{fail_grep} ; EC=$? ; echo salt-call output grep exit code ${EC} ;"
+          # use the non-zer exit code from salt-call, then invert the results of the grep for failures
+          cmd << " [ ${SC} -ne 0 ] && exit ${SC} ; [ ${EC} -eq 0 ] && exit 1 ; [ ${EC} -eq 1 ] && exit 0)"
         end
-
-        # scan the output for signs of failure, there is a risk of false negatives
-        fail_grep = 'grep -e Result.*False -e Data.failed.to.compile -e No.matching.sls.found.for'
-        # capture any non-zero exit codes from the salt-call | tee pipe
-        cmd = 'set -o pipefail ; ' << cmd
-        # Capture the salt-call output & exit code
-        cmd << " 2>&1 | tee /tmp/salt-call-output ; SC=$? ; echo salt-call exit code: $SC ;"
-        # check the salt-call output for fail messages
-        cmd << " (sed '/#{fail_grep}/d' /tmp/salt-call-output | #{fail_grep} ; EC=$? ; echo salt-call output grep exit code ${EC} ;"
-        # use the non-zer exit code from salt-call, then invert the results of the grep for failures
-        cmd << " [ ${SC} -ne 0 ] && exit ${SC} ; [ ${EC} -eq 0 ] && exit 1 ; [ ${EC} -eq 1 ] && exit 0)"
 
         cmd
       end


### PR DESCRIPTION
This allow the state output coloring to show when using newer versions of salt.
