### PR TITLE
make chef install for busser optionally

### DIFF
--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -56,6 +56,7 @@ module Kitchen
       default_config :salt_run_highstate, true
       default_config :salt_copy_filter, []
       default_config :is_file_root, false
+      default_config :require_chef_for_busser, true
 
       default_config :dependencies, []
       default_config :vendor_path, nil
@@ -148,6 +149,15 @@ module Kitchen
             exit 2
           fi
 
+          #{install_chef_for_busser}
+
+          '
+        INSTALL
+      end
+
+      def install_chef_for_busser
+        return unless config[:require_chef_for_busser]
+        <<-INSTALL
           if [ ! -d "/opt/chef" ]
           then
             echo "-----> Installing Chef Omnibus (for busser/serverspec ruby support)"
@@ -158,8 +168,6 @@ module Kitchen
             fi
             #{sudo('sh')} #{omnibus_download_dir}/install.sh -d #{omnibus_download_dir}
           fi
-
-          '
         INSTALL
       end
 

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -12,6 +12,7 @@ salt_version | "0.16.2"| desired version, only affects apt installs
 salt_apt_repo | "http://apt.mccartney.ie"| apt repo
 salt_apt_repo_key| "http://apt.mccartney.ie/KEY"| apt repo key
 salt_ppa | "ppa:saltstack/salt" | Official Ubuntu SaltStack PPA
+require_chef_for_busser | true | Install chef if needed by busser to run tests
 chef_bootstrap_url| "https://www.getchef.com/chef/install.sh"| the chef bootstrap installer, used to provide Ruby for the serverspec test runner on the guest OS
 salt_config| "/etc/salt"|
 [salt_copy_filter](#salt_copy_filter) | [] | List of filenames to be excluded when copying states, formula & pillar data down to guest instances.
@@ -28,7 +29,7 @@ state_collection | false | treat this directory as a salt state collection and n
 [pillars-from-files](#pillars-from-files) | | a list of key-value pairs for files that should be loaded as pillar data
 [grains](#grains) | | a hash to be re-written as /etc/salt/grains on the guest
 [dependencies](#dependencies) | [] | a list of hashes specifying dependencies formulas to be copied into the VM. e.g. [{ :path => 'deps/icinga-formula', :name => 'icinga' }]
-[vendor_path](#vendor_path) |""| path (absolute or relative) to a collection of formula reuired to be copied to the guest 
+[vendor_path](#vendor_path) |""| path (absolute or relative) to a collection of formula reuired to be copied to the guest
 
 
 ##Configuring Provisioner Options
@@ -58,33 +59,33 @@ The provisioner can be configured globally or per suite, global settings act as 
         provisioner:
           salt_version: 0.16.2
           salt_install: apt
-          
-	  - name: tcp-output
-	    provisioner:
-	      pillars:
-	        top.sls:
-	          base:
-	            '*':
-	              - beaver
-	        beaver.sls:
-	          beaver:
-	            transport: tcp
-	    
+
+          - name: tcp-output
+            provisioner:
+              pillars:
+                top.sls:
+                  base:
+                    '*':
+                      - beaver
+                beaver.sls:
+                  beaver:
+                    transport: tcp
+
 in this example, the default suite will install salt via the bootstrap method, meaning that it will get the latest package available for the platform via the [bootstrap shell script](http://bootstrap.saltstack.org). We then define another suite called `default_0162`, this has the provisioner install salt-0.16.2 via apt-get (this defaults to a mini repo of mine, which you can override, my repo only contains 0.16.2)
 
 ### [formula](id:formula)
-When running in normal mode, this must be set to the name of the formula your testing, this name is used to derive the name of the directory that should copied down to the guest.  
+When running in normal mode, this must be set to the name of the formula your testing, this name is used to derive the name of the directory that should copied down to the guest.
 
 For a project layout like this:
 
     .kitchen.yml
     beaver/init.sls
     beaver/foo.sls
-    
+
 formula should be set to ```beaver```
 
 
-If you want all files & directories copied down to the host, see the [is_file_root](#is_file_root) option. 
+If you want all files & directories copied down to the host, see the [is_file_root](#is_file_root) option.
 ### [is_file_root](id:is_file_root)
 Setting the ```is_file_root``` flag allows you to work with a directory tree that more closely resembles a built file_root on a salt-master, where you have may have multiple directories of states or formula.  The project is recursively copied down to guest instance, excluding any hidden files or directories (i.e. .git is not copied down, this is the standard behaviour of ruby's FileUtil.cp_r method)
 
@@ -98,13 +99,13 @@ Consider a directory that looks like this:
     mysql/server.sls
     php/init.sls
     ...
-    
+
 With a .kitchen.yml like this you can now test the completed collection:
 
     ---
     driver:
       name: vagrant
-      
+
     provisioner:
       name: salt_solo
       is_file_root: true
@@ -113,17 +114,17 @@ With a .kitchen.yml like this you can now test the completed collection:
           '*':
             - apache
             - mysql.client
-            
+
     platforms:
       - name: ubuntu-12.04
 
     suites:
       - name: default
-      
+
 In this example, the apache state could use functionality from the php state etc.  You're not just restricted to a single formula.
 
 ### [salt_install](id:salt_install)
-### [salt_bootstrap_options](id:salt_bootstrap_options) 
+### [salt_bootstrap_options](id:salt_bootstrap_options)
 Options to pass to the salt bootstrap installer.  For example, you could choose to install salt from the develop branch like this:
 
     suites:
@@ -131,7 +132,7 @@ Options to pass to the salt bootstrap installer.  For example, you could choose 
         provisioner:
           salt_bootstrap_options: -M -N git develop
 
-Details on the various options available at the [salt-bootstrap](https://github.com/saltstack/salt-bootstrap/blob/develop/bootstrap-salt.sh#L180) documentation. 
+Details on the various options available at the [salt-bootstrap](https://github.com/saltstack/salt-bootstrap/blob/develop/bootstrap-salt.sh#L180) documentation.
 
 ### [salt_copy_filter](id:salt_copy_filter)
 When kitchen copies states, formula & pillars down to the guests it creates to execute the states & run tests against, you can filter out paths that you don't want copied down.  The copy is conducted by ruby's FileUtils.cp method, so all hidden directories are skipped (e.g. ```.git```, ```.kitchen``` etc).
@@ -152,7 +153,7 @@ You can supply a list of paths or files to skip by setting an array in the provi
 ### [salt_version](id:salt_version)
 Version of salt to install, via the git bootstrap method, unless ```salt_install``` is set to ```apt```, in which case the version number is used to generate the package name requested via apt
 
-### [salt_apt_repo](id:salt_apt_repo) 
+### [salt_apt_repo](id:salt_apt_repo)
 ### [salt_apt_repo_key](id:salt_apt_repo_key)
 ### [ salt_ppa](id:salt_ppa)
 Adds the supplied PPA. The default being the Official SaltStack PPA. Useful when the release (e.g. vivid) does not have support via the standard boostrap script or apt repo.
@@ -175,24 +176,24 @@ The states to be applied, this is rendered into top.sls in the guest, you can de
             '*':
               - beaver
               - beaver.ppa
-              
+
       - name: server
         provisioner:
         state_top:
           base:
             '*':
               - beaver.server
-              - beaver.ppa              
+              - beaver.ppa
 
 ### [state_top_from_file](id:state_top_from_file)
-Instead of rendering ```top.sls``` on the guest from the definition in .kitchen.yml, use top.sls found in the repo. 
+Instead of rendering ```top.sls``` on the guest from the definition in .kitchen.yml, use top.sls found in the repo.
 
     suites:
       - name: use-top-from-disk
         provisioner:
           state_top_from_file: true
-          
-          
+
+
 ### [state_collection](id:state_collection)
 Setting the ```state_collection``` flag to true makes kitchen-salt assume that the state files are at the same level as the ```.kitchen.yml```, unlike a formula, where the states are in a directory underneath the directory containing ```.kitchen.yml```.  When using ```state_collection:true```, you must also set the [collection_name](#collection_name).
 
@@ -220,10 +221,10 @@ When dealing with a collection of states, it's necessary to set the primary coll
 
     platforms:
       - name: ubuntu-12.04
-    
+
     suites:
       - name: default
-         
+
 In order for salt-call to be able to find the logrotate state and apply init.sls, the path to init.sls must be logrotate/init.sls, relative to a ```file_roots``` entry.
 
 ### [pillars](id:pillars)
@@ -253,15 +254,15 @@ Consider the following suite definition:
               base:
                 '*':
                   - beaver
-                  
-                  
+
+
 And the contents of pillar.example is a normal pillar file:
 
-	$ cat pillar.example
-	# defaults are set in map.jinja and can be over-ridden like this
-	beaver:
-	  transport: stdout
-	  format: json
+        $ cat pillar.example
+        # defaults are set in map.jinja and can be over-ridden like this
+        beaver:
+          transport: stdout
+          format: json
 
 
 
@@ -282,7 +283,7 @@ For example, the following suite will define grains on the guest:
             deployment: datacenter4
             cabinet: 13
             cab_u: 14-15
-            
+
 ### [dependencies](id:dependencies)
 
 ### [vendor_path](id:vendor_path)


### PR DESCRIPTION
added option to make chef install optionally as it is is in kitchen-puppet and kitchen-ansible. 
