### PR TITLE
Add option to do a dry run highstate

### DIFF
--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -35,6 +35,7 @@ module Kitchen
       include Kitchen::Salt::States
 
       DEFAULT_CONFIG = {
+        dry_run: false,
         salt_version: 'latest',
         salt_install: 'bootstrap',
         salt_bootstrap_url: 'http://bootstrap.saltstack.org',
@@ -121,6 +122,7 @@ module Kitchen
         salt_version = config[:salt_version]
         cmd = sudo("salt-call --config-dir=#{File.join(config[:root_path], config[:salt_config])} --local state.highstate")
         cmd << " --log-level=#{config[:log_level]}" if config[:log_level]
+        cmd << " test=#{config[:dry_run]}" if config[:dry_run]
         if salt_version > RETCODE_VERSION || salt_version == 'latest'
           # hope for the best and hope it works eventually
           cmd += ' --retcode-passthrough'

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -3,6 +3,7 @@
 
 key | default value | Notes
 ----|---------------|--------
+dry_run | false | Setting this to True makes the highstate to run with flag test=True (Ideal for testing states syntax)
 formula | | name of the formula, used to derive the path we need to copy to the guest
 [is_file_root](#is_file_root) | false | Treat this project as a complete file_root, not just a state collection or formula
 salt_install| "bootstrap" | Method by which to install salt, "bootstrap", "apt" or "ppa"


### PR DESCRIPTION
With `dry_run` option you will be able to run highstate with `test=True` argument allowing states syntax format checks.

In my use case I just want to be sure the states are valid before actually running the highstate which in my case takes several minutes.
