### PR TITLE
Fix Salt installation with APT

### DIFF
--- a/lib/kitchen/provisioner/install.erb
+++ b/lib/kitchen/provisioner/install.erb
@@ -28,7 +28,7 @@ then
   fi
 
   echo "-----> Configuring apt repo for salt #{salt_version}"
-  echo "deb #{salt_apt_repo}/salt-#{salt_version} ${DISTRIB_CODENAME} main" | #{sudo('tee')} /etc/apt/sources.list.d/salt-#{salt_version}.list
+  echo "deb #{salt_apt_repo}/#{salt_version} ${DISTRIB_CODENAME} main" | #{sudo('tee')} /etc/apt/sources.list.d/salt-#{salt_version}.list
 
   do_download #{salt_apt_repo_key} /tmp/repo.key
   #{sudo('apt-key')} add /tmp/repo.key


### PR DESCRIPTION
Provisionning don't work when installing Salt from official repositories.
The repo URL is wrong : 

```http://repo.saltstack.com/apt/debian/7/amd64/latest/salt-latest/dists/wheezy/main/binary-amd64/Packages```

It should be : 

```http://repo.saltstack.com/apt/debian/7/amd64/latest/dists/wheezy/main/binary-amd64/Packages```
