### PR TITLE
add Arch Linux support

### DIFF
--- a/assets/install.sh
+++ b/assets/install.sh
@@ -22,6 +22,13 @@ install_file() {
       echo "installing with apt..."
       apt-get install -y $packages
       ;;
+    "archlinux")
+      echo "installing with pacman..."
+      packages="ruby"
+      pacman -Sy --noconfirm $packages
+      # required as otherwise gems will be installed in user's directories
+      echo "gem: --no-user-install" > /etc/gemrc
+      ;;
     "osx")
       echo "installing with brew..."
       brew install $packages
@@ -41,7 +48,7 @@ install_file() {
     report_bug
     exit 1
   fi
-  
+
   # make links to binaries
   mkdir -p /opt/chef/embedded/bin/
   ln -s `which gem` /opt/chef/embedded/bin/
@@ -62,7 +69,8 @@ elif test -f "/etc/redhat-release"; then
   else
     platform="redhat"
   fi
-
+elif test -f "/etc/arch-release"; then
+    platform="archlinux"
 elif test -f "/etc/system-release"; then
   platform=`sed 's/^\(.\+\) release.\+/\1/' /etc/system-release | tr '[A-Z]' '[a-z]'`
   if test "$platform" = "amazon linux ami"; then

--- a/assets/install.sh
+++ b/assets/install.sh
@@ -22,7 +22,7 @@ install_file() {
       echo "installing with apt..."
       apt-get install -y $packages
       ;;
-    "archlinux")
+    "arch")
       echo "installing with pacman..."
       packages="ruby"
       pacman -Sy --noconfirm $packages
@@ -70,7 +70,7 @@ elif test -f "/etc/redhat-release"; then
     platform="redhat"
   fi
 elif test -f "/etc/arch-release"; then
-    platform="archlinux"
+    platform="arch"
 elif test -f "/etc/system-release"; then
   platform=`sed 's/^\(.\+\) release.\+/\1/' /etc/system-release | tr '[A-Z]' '[a-z]'`
   if test "$platform" = "amazon linux ami"; then


### PR DESCRIPTION
Add Arch Linux support. Related to #84 

Would be nice to make this a default install script for `Arch Linux` (not sure if `kitchen-salt` could detect this) as the `omnitruck` / `chef` does not support Arch Linux officially.