### PR TITLE
Use assets/install.sh first (`boostrap_url` parameter)

### DIFF
--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -43,6 +43,7 @@ module Kitchen
         salt_apt_repo: 'http://apt.mccartney.ie',
         salt_apt_repo_key: 'http://apt.mccartney.ie/KEY',
         salt_ppa: 'ppa:saltstack/salt',
+        bootstrap_url: 'https://raw.githubusercontent.com/simonmcc/kitchen-salt/master/assets/install.sh',
         chef_bootstrap_url: 'https://www.getchef.com/chef/install.sh',
         salt_config: '/etc/salt',
         salt_minion_config: '/etc/salt/minion',
@@ -90,10 +91,20 @@ module Kitchen
         return unless config[:require_chef]
         chef_url = config[:chef_bootstrap_url]
         omnibus_download_dir = config[:omnibus_cachier] ? '/tmp/vagrant-cache/omnibus_chef' : '/tmp'
+        bootstrap_url = config[:bootstrap_url]
+        bootstrap_download_dir = '/tmp'
         <<-INSTALL
-          if [ ! -d "/opt/chef" ]
+          echo "-----> Trying to install ruby(-dev) using assets.sh from kitchen-salt"
+            mkdir -p #{bootstrap_download_dir}
+            if [ ! -x #{bootstrap_download_dir}/install.sh ]
+            then
+              do_download #{bootstrap_url} #{bootstrap_download_dir}/install.sh
+            fi
+            #{sudo('sh')} #{bootstrap_download_dir}/install.sh -d #{bootstrap_download_dir}
+          if [ $? -ne 0 ] || [ ! -d "/opt/chef" ]
           then
-            echo "-----> Installing Chef Omnibus (for busser/serverspec ruby support)"
+            echo "Failed install ruby(-dev) using assets.sh from kitchen-salt"
+            echo "-----> Fallback to Chef Bootstrap script (for busser/serverspec ruby support)"
             mkdir -p #{omnibus_download_dir}
             if [ ! -x #{omnibus_download_dir}/install.sh ]
             then

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -13,7 +13,7 @@ salt_version | "0.16.2"| desired version, only affects apt installs
 salt_apt_repo | "http://apt.mccartney.ie"| apt repo
 salt_apt_repo_key| "http://apt.mccartney.ie/KEY"| apt repo key
 salt_ppa | "ppa:saltstack/salt" | Official Ubuntu SaltStack PPA
-bootstrap_url| "https://raw.githubusercontent.com/simonmcc/kitchen-salt/master/assets/install.sh"| A bootstrap script used to provide Ruby (`ruby` and `ruby-dev`) required for the serverspec test runner on the guest OS. If this script is unable to setup Ruby, it will fallback to installing chef bootstrap installed (set via `chef_bootstrap_url`)
+bootstrap_url| "https://raw.githubusercontent.com/simonmcc/kitchen-salt/master/assets/install.sh"| A bootstrap script used to provide Ruby (`ruby` and `ruby-dev`) required for the serverspec test runner on the guest OS. If this script is unable to setup Ruby, it will fallback to using Chef bootstrap installer (set via `chef_bootstrap_url`)
 chef_bootstrap_url| "https://www.getchef.com/chef/install.sh"| the chef bootstrap installer, used to provide Ruby for the serverspec test runner on the guest OS. However required is only a ruby, under assets/install.sh is an alternative (Chef free) bootstrap script prom PR#42. Example no-"chef_bootstrap url": https://raw.githubusercontent.com/simonmcc/kitchen-salt/assets/install.sh
 require_chef | true | Install chef ( needed by busser to run tests, if no verification driver is specified in kitchen yml)
 salt_config| "/etc/salt"|

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -13,6 +13,7 @@ salt_version | "0.16.2"| desired version, only affects apt installs
 salt_apt_repo | "http://apt.mccartney.ie"| apt repo
 salt_apt_repo_key| "http://apt.mccartney.ie/KEY"| apt repo key
 salt_ppa | "ppa:saltstack/salt" | Official Ubuntu SaltStack PPA
+bootstrap_url| "https://raw.githubusercontent.com/simonmcc/kitchen-salt/master/assets/install.sh"| A bootstrap script used to provide Ruby (`ruby` and `ruby-dev`) required for the serverspec test runner on the guest OS. If this script is unable to setup Ruby, it will fallback to installing chef bootstrap installed (set via `chef_bootstrap_url`)
 chef_bootstrap_url| "https://www.getchef.com/chef/install.sh"| the chef bootstrap installer, used to provide Ruby for the serverspec test runner on the guest OS. However required is only a ruby, under assets/install.sh is an alternative (Chef free) bootstrap script prom PR#42. Example no-"chef_bootstrap url": https://raw.githubusercontent.com/simonmcc/kitchen-salt/assets/install.sh
 require_chef | true | Install chef ( needed by busser to run tests, if no verification driver is specified in kitchen yml)
 salt_config| "/etc/salt"|


### PR DESCRIPTION
This PR tries to first use `assets/install.sh in the master repository. Only if that script will fail it will fallback to the old Chef Bootstrap Omnibus script.

Fixes #90