### PR TITLE
Windows init_command updates

### DIFF
--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -150,7 +150,7 @@ module Kitchen
       def init_command
         debug("Initialising Driver #{name}")
         if windows_os?
-          cmd = "mkdir -Path ""#{config[:root_path]}"""
+          cmd = "mkdir -Force -Path ""#{config[:root_path]}"""
         else
           cmd = "mkdir -p '#{config[:root_path]}';"
         end


### PR DESCRIPTION
Pass "-Force" option to mkdir on windows.  If a converge has previously been run, the init_command will fail on the mkdir.