### PR TITLE
Fix symbolic link, salt_solo.rb and bash if statements

### DIFF
--- a/assets/install.sh
+++ b/assets/install.sh
@@ -55,8 +55,8 @@ install_file() {
 
   # make links to binaries
   mkdir -p /opt/chef/embedded/bin/
-  ln -sf `which gem` /opt/chef/embedded/bin/
-  ln -sf `which ruby` /opt/chef/embedded/bin/
+  [[ ! -e /opt/chef/embedded/bin/gem ]] && ln -s `which gem` /opt/chef/embedded/bin/
+  [[ ! -e /opt/chef/embedded/bin/ruby ]] && ln -s `which ruby` /opt/chef/embedded/bin/
 }
 
 if test -f "/etc/debian_version"; then
@@ -121,3 +121,4 @@ fi
 
 # do the thing
 install_file $platform
+exit 0

--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -128,9 +128,11 @@ module Kitchen
                 echo "Failed install ruby(-dev) using assets.sh from kitchen-salt"
                 echo "-----> Fallback to Chef Bootstrap script (for busser/serverspec ruby support)"
                 mkdir -p "#{omnibus_download_dir}"
-                if [ ! -x #{omnibus_download_dir}/install.sh ] ; then
+                if [ ! -x #{omnibus_download_dir}/install.sh ]
+                then
                     #{sudo('sh')} #{omnibus_download_dir}/install.sh -d #{omnibus_download_dir}
                 fi;
+              fi
           INSTALL
         end
       end


### PR DESCRIPTION
* add fi at end of the if for the salt_solo.rb
* update the if statement from previous commit, to look similar to previous statements in salt_solo.rb
* Test to see if the file exists for gem and ruby, rather than forcing the symbolic link, otherwise it shows a warning
* exit with exit 0 in the install.sh by default. This then doesn't fail the `salt-call`

This is a further fix for #107, after testing #110