### PR TITLE
fix if statement for ruby links

### DIFF
--- a/assets/install.sh
+++ b/assets/install.sh
@@ -55,8 +55,8 @@ install_file() {
 
   # make links to binaries
   mkdir -p /opt/chef/embedded/bin/
-  [[ ! -e /opt/chef/embedded/bin/gem ]] && ln -s `which gem` /opt/chef/embedded/bin/
-  [[ ! -e /opt/chef/embedded/bin/ruby ]] && ln -s `which ruby` /opt/chef/embedded/bin/
+  [ ! -e /opt/chef/embedded/bin/gem ] && ln -s `which gem` /opt/chef/embedded/bin/
+  [ ! -e /opt/chef/embedded/bin/ruby ] && ln -s `which ruby` /opt/chef/embedded/bin/
 }
 
 if test -f "/etc/debian_version"; then


### PR DESCRIPTION
confirmed this works in sh, dash, and bash.

```
root@default-bento-debian-87:/tmp# sh install.sh
Installing the ruby things
installing with apt...
Reading package lists... Done
Building dependency tree
Reading state information... Done
ruby is already the newest version.
ruby-dev is already the newest version.
0 upgraded, 0 newly installed, 0 to remove and 56 not upgraded.
root@default-bento-debian-87:/tmp# bash install.sh
Installing the ruby things
installing with apt...
Reading package lists... Done
Building dependency tree
Reading state information... Done
ruby is already the newest version.
ruby-dev is already the newest version.
0 upgraded, 0 newly installed, 0 to remove and 56 not upgraded.
```