### PR TITLE
Fix Salt version comparison on Salt install

### DIFF
--- a/lib/kitchen/provisioner/install.erb
+++ b/lib/kitchen/provisioner/install.erb
@@ -54,6 +54,14 @@ fi
 # check again, now that an install of some form should have happened
 SALT_VERSION=`salt-call --version | cut -d " " -f 2`
 
+# extract short format of Salt version
+if [ ! -z "${SALT_VERSION}" ]
+then
+  YEAR=$(echo "$SALT_VERSION" | cut -d "." -f1)
+  MONTH=$(echo "$SALT_VERSION" | cut -d "." -f2)
+  SALT_VERSION="${YEAR}.${MONTH}"
+fi
+
 if [ -z "${SALT_VERSION}" ]
 then
   echo "No salt-minion installed, install must have failed!!"


### PR DESCRIPTION
We specifiy `2016.11` in .kitchen.yml but Salt return `2016.11.6` as version
Thus `2016.11 != 2016.11.6`