### PR TITLE
Add "yum" option for salt_install for RHEL based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ The provider works by generating a salt-minion config, creating pillars based on
 This provider has been tested against the Ubuntu boxes running in vagrant/virtualbox & vagrant-lxc boxes on Ubuntu.
 
 ## Installation & Setup
-You'll need the test-kitchen & kitchen-salt gem's installed in your system, along with kitchen-vagrant or some other suitable driver for test-kitchen.  Please see the [INTRODUCTION](https://github.com/saltstack/kitchen-salt/blob/master/INTRODUCTION.md).
+You'll need the test-kitchen & kitchen-salt gem's installed in your system, along with kitchen-vagrant or some other suitable driver for test-kitchen.  Please see the [INTRODUCTION](INTRODUCTION.md).
 
-## Provisioner Options 
-More details on all the configuration optins are in [provisioner_options.md](https://github.com/saltstack/kitchen-salt/blob/master/provisioner_options.md)
+## Provisioner Options
+More details on all the configuration optins are in [provisioner_options.md](provisioner_options.md)
 
 ## Catching salt failures
 Catching salt failures is particularly troublesome, as salt & salt-call don't do a very good job of setting the exit
 code to something useful, around ~0.17.5, the `--retcode-passthrough` option was added, but even in 2014.1.0 this is
-still flawed, [PR11337](https://github.com/saltstack/salt/pull/11337) should help fix some of those problems.  In the
+still flawed, saltstack/salt#11337 should help fix some of those problems.  In the
 mean time, we scan the salt-call output for signs of failure (essentially `grep -e Result.*False -e Data.failed.to.compile -e
 No.matching.sls.found.for`) and check for a
 non-zero exit code from salt-call.
@@ -28,7 +28,7 @@ non-zero exit code from salt-call.
 You'll need a driver box that is supported by both the SaltStack [bootstrap](https://github.com/saltstack/salt-bootstrap) system & the Chef Omnibus installer (the Chef Omnibus installer is only needed to provide busser with a useable ruby environment, you can tell busser to use an alternative ruby if your box has suitable ruby support built in).
 
 ## Continuous Integration & Testing
-PR's and other changes should validated using Travis-CI and the test-kitchen branch of [beaver-formula](https://github.com/simonmcc/beaver-formula/blob/test-kitchen/.kitchen.yml), this uses the kitchen-ec2 driver, the version of kitchen-salt under review & the latest release of test-kitchen. 
+PR's and other changes should validated using Travis-CI and the test-kitchen branch of [beaver-formula](https://github.com/simonmcc/beaver-formula/blob/test-kitchen/.kitchen.yml), this uses the kitchen-ec2 driver, the version of kitchen-salt under review & the latest release of test-kitchen.
 
 * http://oj.io/ci/aws-credentials-and-travis-ci/
 

--- a/lib/kitchen/provisioner/install.erb
+++ b/lib/kitchen/provisioner/install.erb
@@ -49,6 +49,26 @@ then
   #{sudo('apt-add-repository')} -y #{salt_ppa}
   #{sudo('apt-get')} update
   #{sudo('apt-get')} install -y salt-minion salt-common
+elif [ -z "${SALT_VERSION}" -a "#{salt_install}" = "yum" ]
+  if [ -z "#{salt_version}" ]
+  then
+    echo "-----> Installing ppa repo for salt latest"
+    #{sudo('yum')} install https://repo.saltstack.com/yum/redhat/salt-repo-latest-2.el7.noarch.rpm
+  else
+    echo "-----> Installing ppa repo for salt #{salt_version}"
+    #{sudo('rpm')} --import 'https://repo.saltstack.com/yum/redhat/7/x86_64/archive/#{salt_version}/SALTSTACK-GPG-KEY.pub'
+    #{sudo('tee')} /etc/yum.repos.d/saltstack.repo <<EOL
+[saltstack-repo]
+name=SaltStack repo for RHEL/CentOS $releasever
+baseurl=#{Shellwords.escape("https://repo.saltstack.com/yum/redhat/$releasever/$basearch/archive/#{salt_version}")}
+enabled=1
+gpgcheck=1
+gpgkey=#{Shellwords.escape("https://repo.saltstack.com/yum/redhat/$releasever/$basearch/archive/#{salt_version}/SALTSTACK-GPG-KEY.pub")}
+EOL
+  fi
+  #{sudo('yum')} clean expire-cache
+  echo "-----> Installing salt-minion (#{salt_version})"
+  #{sudo('yum')} install -y salt-minion salt-common
 fi
 
 # check again, now that an install of some form should have happened

--- a/lib/kitchen/provisioner/install.erb
+++ b/lib/kitchen/provisioner/install.erb
@@ -53,10 +53,10 @@ then
 elif [ -z "${SALT_VERSION}" -a "#{salt_install}" = "yum" ]
   if [ -z "#{salt_version}" ]
   then
-    echo "-----> Installing ppa repo for salt latest"
+    echo "-----> Installing yum repo for salt latest"
     #{sudo('yum')} install https://repo.saltstack.com/yum/redhat/salt-repo-latest-2.el7.noarch.rpm
   else
-    echo "-----> Installing ppa repo for salt #{salt_version}"
+    echo "-----> Installing yum repo for salt #{salt_version}"
     #{sudo('rpm')} --import 'https://repo.saltstack.com/yum/redhat/7/x86_64/archive/#{salt_version}/SALTSTACK-GPG-KEY.pub'
     #{sudo('tee')} /etc/yum.repos.d/saltstack.repo <<EOL
 [saltstack-repo]

--- a/lib/kitchen/provisioner/install.erb
+++ b/lib/kitchen/provisioner/install.erb
@@ -51,6 +51,7 @@ then
   #{sudo('apt-get')} update
   #{sudo('apt-get')} install -y salt-minion salt-common
 elif [ -z "${SALT_VERSION}" -a "#{salt_install}" = "yum" ]
+then
   if [ -z "#{salt_version}" ]
   then
     echo "-----> Installing yum repo for salt latest"

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -7,7 +7,7 @@ dry_run | false | Setting this to True makes the highstate to run with flag test
 formula | | name of the formula, used to derive the path we need to copy to the guest
 [is_file_root](#is_file_root) | false | Treat this project as a complete file_root, not just a state collection or formula
 log_level | | set salt logging level when running commands (e.g. specifying `debug` is equivalent of `-l debug`)
-salt_install| "bootstrap" | Method by which to install salt, "bootstrap", "apt", "distrib" or "ppa"
+[salt_install](#salt_install) | "bootstrap" | Method by which to install salt, "bootstrap", "apt", "distrib", "ppa", or "yum"
 salt_bootstrap_url | "https://bootstrap.saltstack.com" | location of bootstrap script
 [salt_bootstrap_options](#salt_bootstrap_options) | | optional options passed to the salt bootstrap script
 salt_version | "latest"| desired version, only affects apt installs
@@ -139,6 +139,7 @@ Choose your method to install SaltStack :
 * **apt :** install SaltStack from specified repository (see: [salt_apt_repo](id:salt_apt_repo))
 * **ppa :** install SaltStack from ppa repository (see: [salt_ppa](id:salt_ppa))
 * **distrib :** install SaltStack from distribution repositories
+* **yum :** install SaltStack from yum repository for RHEL based systems
 
 ### [salt_bootstrap_options](id:salt_bootstrap_options)
 Options to pass to the salt bootstrap installer.  For example, you could choose to install salt from the develop branch like this:
@@ -167,7 +168,9 @@ You can supply a list of paths or files to skip by setting an array in the provi
 
 
 ### [salt_version](id:salt_version)
-Version of salt to install, via the git bootstrap method, unless ```salt_install``` is set to ```apt```, in which case the version number is used to generate the package name requested via apt
+Version of salt to install. If [`salt_install`](#salt_install) is set to
+anything other than `'bootstrap'` (default) then this value will be
+injected into the configuration specific to that installation method.
 
 ### [salt_apt_repo](id:salt_apt_repo)
 ### [salt_apt_repo_key](id:salt_apt_repo_key)


### PR DESCRIPTION
It would be nice if this eventually supported all the various package repositories defined here: https://repo.saltstack.com/ . However that seems like a lot of breaking changes, so this just adds the ability to define `salt_install` as `'yum'` as a stop gap.

Longer term it'd probably make sense to have an install script per os family pulled by the detected system information, and then each of those would have nested options. This will likely break things though; for example the `salt_ppa` provisioner option should probably be `salt_apt_ppa`, or `salt_apt` should be a configuration object with numerous sub keys.