### PR TITLE
Use -replace to support Powershell 2.0 on Server 2008r2

### DIFF
--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -220,7 +220,7 @@ module Kitchen
         if windows_os?
           salt_call = "c:\\salt\\salt-call.bat"
           salt_config_path = config[:salt_config].gsub('/', '\\')
-          cmd << "(get-content #{File.join(config[:root_path], salt_config_path, 'minion').gsub('/', '\\')}).replace(\"`$env`:TEMP\", $env:TEMP) | set-content #{File.join(config[:root_path], salt_config_path, 'minion').gsub('/', '\\')} ;"
+          cmd << "(get-content #{File.join(config[:root_path], salt_config_path, 'minion').gsub('/', '\\')}) -replace '\\$env:TEMP', $env:TEMP | set-content #{File.join(config[:root_path], salt_config_path, 'minion').gsub('/', '\\')} ;"
         else
           # install/update dependencies
           cmd << sudo("chmod +x #{config[:root_path]}/*.sh;")

--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -351,7 +351,6 @@ module Kitchen
         dependencies_script = File.expand_path("./../dependencies.erb", __FILE__)
         dependencies_content = ERB.new(File.read(dependencies_script)).result(binding)
         write_raw_file(File.join(sandbox_path, 'dependencies.sh'), dependencies_content)
-
       end
     end
   end


### PR DESCRIPTION
Salt [officially supports Windows Server 2008r2](http://saltstack.com/wp-content/uploads/2016/08/SaltStack-Supported-Operating-Systems.pdf) which runs PowerShell 2.0. This PR makes a slight change to the `salt_command` method to support PowerShell 2.0. Credit to [this SO post](https://stackoverflow.com/questions/35641714/system-object-doesnt-contain-a-methodnamed-replace) for explaining why calling `.replace()` fails and suggesting to use `-replace` instead.