### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,3 +1,15 @@
+v0.2.0
+
+* Added ability to copy drop-in files to the minion configuration
+  See 
+  https://github.com/saltstack/kitchen-salt/blob/master/docs/provisioner_options.md#salt_minion_extra_config
+* Provides support for PowerShell 2.0 under Windows Server 2008r2
+* Fixed a bug where `salt_install: none` would fail on Windows
+
+v0.1.0
+
+* Two years worth of changes. You'll need to browse the commit history, sorry!
+
 v0.0.19
 * Added ability to copy additional dependency formulas into the VM
   See https://github.com/saltstack/kitchen-salt/blob/master/provisioner_options.md#dependencies

--- a/lib/kitchen-salt/version.rb
+++ b/lib/kitchen-salt/version.rb
@@ -1,5 +1,5 @@
 module Kitchen
   module Salt
-    VERSION = '0.1.0'.freeze
+    VERSION = '0.2.0'.freeze
   end
 end


### PR DESCRIPTION
This propose a release of changes made since `v0.1.0`.

I'll create another PR for a CI and a release hook that's worked well in the past for managing changelog and releases. I have to say I don't have the courage right now to backfill the changelog all the way to `v0.19.0`! 😅