### PR TITLE
Show debug output on Windows

### DIFF
--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -240,7 +240,7 @@ module Kitchen
           # hope for the best and hope it works eventually
           cmd << ' --retcode-passthrough'
         end
-        cmd << ' ; exit $LASTEXITCODE' if windows_os?
+        cmd << ' 2>&1 ; exit $LASTEXITCODE' if windows_os?
         cmd
       end
 


### PR DESCRIPTION
When setting `log_level: debug` in the provisioner options, salt debug output isn't showing the kitchen output. This PR fixes this issue by redirecting stderr to stdout on Windows. When omitting `log_level` the kitchen output is unchanged with this PR, so current users won't notice any difference.