### PR TITLE
Add salt_version to salt_bootstrap_options if %s is specified

### DIFF
--- a/docs/provisioner_options.md
+++ b/docs/provisioner_options.md
@@ -359,6 +359,20 @@ For the Windows Powershell script:
         salt_bootstrap_script: https://github.com/saltstack/salt-bootstrap/blob/develop/bootstrap-salt.ps1
         salt_bootstrap_options: -version 2017.7.2
 
+You can also use `%s` in any part of this, to replace with the version of salt, as specified by `salt_version`
+
+For example, below is a custom bootstrap option for centos6 requiring python2.7, here `%s` gets replaced by `2018.3`
+
+    platform:
+      - centos-6:
+        salt_bootstrap_options: "-P -p git -p curl -p sudo -y -x python2.7 git %s"
+    
+    suites:
+      - name: oxygen
+        provisioner:
+          salt_version: '2018.3'
+          salt_install: bootstrap
+
 ### salt_apt_repo ###
 
 default: `https://repo.saltstack.com/apt/ubuntu/16.04/amd64/`

--- a/lib/kitchen/provisioner/install.erb
+++ b/lib/kitchen/provisioner/install.erb
@@ -1,8 +1,8 @@
 <%=
 salt_install = config[:salt_install]
 salt_url = config[:salt_bootstrap_url]
-bootstrap_options = config[:salt_bootstrap_options]
 salt_version = config[:salt_version]
+bootstrap_options = config[:salt_bootstrap_options] % [salt_version]
 salt_apt_repo = config[:salt_apt_repo]
 salt_apt_repo_key = config[:salt_apt_repo_key]
 salt_ppa = config[:salt_ppa]


### PR DESCRIPTION
This allows to dynamically include different versions of salt within the same
.kitchen.yml file, and therefore don't require an external script to manage