### PR TITLE
Set runservice setting for windows bootstrap script

### DIFF
--- a/docs/jenkins.md
+++ b/docs/jenkins.md
@@ -178,7 +178,7 @@ The following fields will need to be filled out:
         retryable_tries: 120
       provisioner:
         salt_bootstrap_url: https://raw.githubusercontent.com/saltstack/salt-bootstrap/develop/bootstrap-salt.ps1
-        salt_bootstrap_options: -version <%= version %>
+        salt_bootstrap_options: -version <%= version %> -runservice false
         init_environment: |
           reg add "hklm\system\currentcontrolset\control\session manager\memory management" /v pagingfiles /t reg_multi_sz /d "d:\pagefile.sys 4096 8192" /f
           winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="5000"}'


### PR DESCRIPTION
Do not start service when running bootstrap script. A running minion service can cause some tests to fail. While we should also fix those tests, this will at least get them passing for now.