### PR TITLE
Honor real exit code for windows builds

### DIFF
--- a/lib/kitchen/verifier/runtests.rb
+++ b/lib/kitchen/verifier/runtests.rb
@@ -23,7 +23,7 @@ module Kitchen
 
       def call(state)
         info("[#{name}] Verify on instance #{instance.name} with state=#{state}")
-        root_path = (config[:windows] ? '$env:TEMP\\kitchen' : '/tmp/kitchen')
+        root_path = (config[:windows] ? '%TEMP%\\kitchen' : '/tmp/kitchen')
         if ENV['KITCHEN_TESTS']
           ENV['KITCHEN_TESTS'].split(' ').each{|test| config[:tests].push(test)}
         end
@@ -42,6 +42,9 @@ module Kitchen
           config[:tests].collect{|test| "-n #{test}"}.join(' '),
           '2>&1',
         ].join(' ')
+        if config[:windows]
+           command = "cmd.exe /c \"#{command}\" 2>&1"
+        end
         info("Running Command: #{command}")
         instance.transport.connection(state) do |conn|
           begin


### PR DESCRIPTION
The winrm library checks the status of $? and Fails if it is not true.
Powershell sets $? to False if anything is written stderr by the script.
Work around this by excuting the test run with cmd.exe and doing the
redirection there.

The line that causes this in ruby's winrm library is here:

https://github.com/WinRb/WinRM/blob/master/lib/winrm/shells/power_shell.rb#L101

See this stack thread for more info:

https://stackoverflow.com/questions/10666101/lastexitcode-0-but-false-in-powershell-redirecting-stderr-to-stdout-gives-n