### PR TITLE
use format strings for sudo command

### DIFF
--- a/lib/kitchen/verifier/runtests.rb
+++ b/lib/kitchen/verifier/runtests.rb
@@ -20,6 +20,13 @@ module Kitchen
       default_config :transport, false
       default_config :save, {}
       default_config :windows, false
+      default_config :sudo_command do |verifier|
+        verifier.windows_os? ? nil : 'sudo env -i bash -l -c "%s"'
+      end
+
+      def sudo(script)
+        config[:sudo] ? config[:sudo_command] % script : script
+      end
 
       def call(state)
         info("[#{name}] Verify on instance #{instance.name} with state=#{state}")


### PR DESCRIPTION
This will be closer to running the shell command actually as root, it
will remove a lot of the extra sudo environment stuff, and will create a
clean environment for running the test suite, as if we had actually
logged in as root.