### PR TITLE
Move the -R option for chown to precede the user:group

### DIFF
--- a/lib/kitchen/provisioner/dependencies.erb
+++ b/lib/kitchen/provisioner/dependencies.erb
@@ -92,7 +92,7 @@ def install_dependencies
   end
   script += <<-INSTALL
     linkFormulas "$SALT_ROOT"
-    chown "${SUDO_USER:-$USER}" -R "${SALT_SHARE_DIR}" "${SALT_ROOT}";
+    chown -R "${SUDO_USER:-$USER}" "${SALT_SHARE_DIR}" "${SALT_ROOT}";
     echo "Content of $SALT_ROOT :";
     ls -la "$SALT_ROOT";
   INSTALL

--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -111,7 +111,7 @@ module Kitchen
         cmd = ''
         unless windows_os?
           cmd += <<-CHOWN
-            #{sudo('chown')} "${SUDO_USER:-$USER}" -R "#{config[:root_path]}/#{config[:salt_file_root]}"
+            #{sudo('chown')} -R "${SUDO_USER:-$USER}" "#{config[:root_path]}/#{config[:salt_file_root]}"
           CHOWN
         end
         if config[:prepare_salt_environment]


### PR DESCRIPTION
macOS 10.9 fails with the command:
```
chown user:group -R path
```
Moving the recursive option to precede the user and group fixes this:
```
chown -R user:group path
```

A quick check of some online references show putting options before the user:group and path(s) is the default order:
* https://linux.die.net/man/1/chown
* http://manpages.ubuntu.com/manpages/bionic/man1/chown.1.html
* https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man8/chown.8.html