### PR TITLE
upgrade setuptools

### DIFF
--- a/lib/kitchen/provisioner/install.erb
+++ b/lib/kitchen/provisioner/install.erb
@@ -39,6 +39,8 @@ then
   #{sudo('sh')} $BOOTSTRAP #{bootstrap_options}
 elif [ -z "${SALT_VERSION}" -a "#{salt_install}" = "pip" ]
 then
+  echo "Makesure setuptools is new enough"
+  #{sudo(salt_pip_bin)} install "setuptools>=30"
   echo #{sudo(salt_pip_bin)} #{salt_pip_install_command} #{salt_pip_pkg}
   #{sudo(salt_pip_bin)} #{salt_pip_install_command} #{salt_pip_pkg}
 elif [ -z "${SALT_VERSION}" -a "#{salt_install}" = "apt" ]


### PR DESCRIPTION
A newer setuptools may be required to handle changes to the salt
requirements.txt file.