### PR TITLE
Run commands on cache dir

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -128,6 +128,9 @@ platforms:
       name: vagrant
       gui: true
     provisioner:
+      # On Osx 'brew install unix2dos' or Centos 'yum install tofrodos'
+      cache_commands:
+        - find %{sandbox_path} -type f | xargs unix2dos
       init_environment: |
         Clear-Host
         $AddedLocation ="c:\salt"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,6 +15,8 @@ provisioner:
   salt_bootstrap_options: -X -p git -p curl -p sudo
   formula: tests
   require_chef: false
+  cache_commands:
+    - touch %{sandbox_path}/srv/salt/cache_commands_test
   init_environment: |
     sudo mkdir -p /tmp/kitchen/var/cache/salt/master
   salt_copy_filter:
@@ -130,6 +132,7 @@ platforms:
     provisioner:
       # On Osx 'brew install unix2dos' or Centos 'yum install tofrodos'
       cache_commands:
+        - touch %{sandbox_path}/srv/salt/cache_commands_test
         - find %{sandbox_path} -type f | xargs unix2dos
       init_environment: |
         Clear-Host

--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -198,6 +198,7 @@ module Kitchen
         prepare_grains
         prepare_states
         prepare_state_top
+        prepare_cache_commands
         # upload scripts, cached formulas, and setup system repositories
         prepare_dependencies
       end

--- a/tests/integration/test_salt.py
+++ b/tests/integration/test_salt.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals, print_function
 import os
 import pytest
 
@@ -45,3 +46,11 @@ def test_path_depends(salt):
     dirs = salt('cp.list_master_dirs')
     print(dirs)
     assert all([formula in dirs for formula in formulas])
+
+
+def test_path_line_endings(salt):
+    res = salt('cp.get_file_str', 'salt://top.sls')
+    if 'windows' in os.environ.get('KITCHEN_INSTANCE'):
+        assert res == '---\r\nbase:\r\n  "*":\r\n  - foo\r\n'
+    else:
+        assert res == '---\nbase:\n  "*":\n  - foo\n'

--- a/tests/integration/test_salt.py
+++ b/tests/integration/test_salt.py
@@ -47,10 +47,12 @@ def test_path_depends(salt):
     print(dirs)
     assert all([formula in dirs for formula in formulas])
 
+
 def test_cache_command_ran(salt):
     files = salt('cp.list_master')
     print(files)
     assert 'cache_commands_test' in files
+
 
 @pytest.mark.skipif('windows' not in os.environ.get('KITCHEN_INSTANCE'), reason='Skip windows specific test')
 def test_path_line_endings(salt):

--- a/tests/integration/test_salt.py
+++ b/tests/integration/test_salt.py
@@ -47,10 +47,12 @@ def test_path_depends(salt):
     print(dirs)
     assert all([formula in dirs for formula in formulas])
 
+def test_cache_command_ran(salt):
+    files = salt('cp.list_master')
+    print(files)
+    assert 'cache_commands_test' in files
 
+@pytest.mark.skipif('windows' not in os.environ.get('KITCHEN_INSTANCE'), reason='Skip windows specific test')
 def test_path_line_endings(salt):
     res = salt('cp.get_file_str', 'salt://top.sls')
-    if 'windows' in os.environ.get('KITCHEN_INSTANCE'):
-        assert res == '---\r\nbase:\r\n  "*":\r\n  - foo\r\n'
-    else:
-        assert res == '---\nbase:\n  "*":\n  - foo\n'
+    assert res == '---\r\nbase:\r\n  "*":\r\n  - foo\r\n'


### PR DESCRIPTION
Run commands on the local host after the cache directory is created.

An example of this might be to run a command on Windows suites
```
  provisioner:
    cache_commands:
      - find %{sandbox_path} -type f | xargs unix2dos
```