### PR TITLE
Don't include names file if specific tests provided

### DIFF
--- a/lib/kitchen/verifier/runtests.rb
+++ b/lib/kitchen/verifier/runtests.rb
@@ -32,7 +32,7 @@ module Kitchen
           File.join(root_path, config[:testingdir], '/tests/runtests.py'),
           '--sysinfo',
           '--output-columns=80',
-          (config[:windows] ? "--names-file=#{root_path}\\testing\\tests\\whitelist.txt" : ''),
+          (config[:windows] && config[:tests].empty? ? "--names-file=#{root_path}\\testing\\tests\\whitelist.txt" : ''),
           (config[:transport] ? "--transport=#{config[:transport]}" : ''),
           (config[:verbose] ? '-vv' : '-v'),
           (config[:run_destructive] ? "--run-destructive" : ''),


### PR DESCRIPTION
Setting the KITCHEN_TESTS variable should override names on Windows OS. Do not include the names file when specific tests are provided via the KITCHEN_TESTS environment variable.