### PR TITLE
add transport using ssh on commandline

### DIFF
--- a/lib/kitchen/transport/runtests.rb
+++ b/lib/kitchen/transport/runtests.rb
@@ -1,0 +1,26 @@
+require 'kitchen/transport/rsync'
+require 'shellwords'
+
+module Kitchen
+  module Transport
+    class Runtests < Kitchen::Transport::Rsync
+      class Connection < Kitchen::Transport::Rsync::Connection
+        def execute_with_exit_code(command)
+          if command.start_with?("sh -c")
+            super
+          else
+            login = login_command()
+            cmd = [
+              login.instance_variable_get("@command"),
+              login.instance_variable_get("@arguments").join(' '),
+              '--',
+              command.shellescape,
+            ].join(' ')
+            system(cmd)
+            $?.exitstatus
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We have been having problems with net-ssh dieing during a test run.

[closed stream] is the error message, going to try using the ssh binary
to run the commands when easily possible.