### PR TITLE
install.sh: Re-add explicit exit at the end of the script

### DIFF
--- a/assets/install.sh
+++ b/assets/install.sh
@@ -139,3 +139,4 @@ fi
 
 # Install dependencies
 install_deps "$platform"
+exit 0


### PR DESCRIPTION
The latest release broke some of our formula testing. Specifically, on
the second install run, the last line in `install_deps` returns 1 as
the ruby binary it's looking for doesn't exist:

```
[ ! -e /opt/chef/embedded/bin/ruby ] && ln -s "$(command -v ruby)" /opt/chef/embedded/bin/
```

This results in the script as a whole returning `1`, which results in 
test-kitchen bombing out with a ruby backtrace that looks like:

```
E, [2018-10-11T19:32:53.209388 #65496] ERROR -- custom-bento-debian-85: ------Backtrace-------
E, [2018-10-11T19:32:53.209408 #65496] ERROR -- custom-bento-debian-85: /Library/Ruby/Gems/2.3.0/gems/test-kitchen-1.21.2/lib/kitchen/provisioner/base.rb:91:in `rescue in call'
E, [2018-10-11T19:32:53.209428 #65496] ERROR -- custom-bento-debian-85: /Library/Ruby/Gems/2.3.0/gems/test-kitchen-1.21.2/lib/kitchen/provisioner/base.rb:94:in `call'
E, [2018-10-11T19:32:53.209448 #65496] ERROR -- custom-bento-debian-85: /Library/Ruby/Gems/2.3.0/gems/test-kitchen-1.21.2/lib/kitchen/instance.rb:393:in `block in converge_action'
E, [2018-10-11T19:32:53.209468 #65496] ERROR -- custom-bento-debian-85: /Library/Ruby/Gems/2.3.0/gems/test-kitchen-1.21.2/lib/kitchen/instance.rb:536:in `synchronize_or_call'
E, [2018-10-11T19:32:53.209506 #65496] ERROR -- custom-bento-debian-85: /Library/Ruby/Gems/2.3.0/gems/test-kitchen-1.21.2/lib/kitchen/instance.rb:498:in `block in action'
E, [2018-10-11T19:32:53.209527 #65496] ERROR -- custom-bento-debian-85: /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/benchmark.rb:293:in `measure'
E, [2018-10-11T19:32:53.209547 #65496] ERROR -- custom-bento-debian-85: /Library/Ruby/Gems/2.3.0/gems/test-kitchen-1.21.2/lib/kitchen/instance.rb:497:in `action'
E, [2018-10-11T19:32:53.209566 #65496] ERROR -- custom-bento-debian-85: /Library/Ruby/Gems/2.3.0/gems/test-kitchen-1.21.2/lib/kitchen/instance.rb:389:in `converge_action'
E, [2018-10-11T19:32:53.209586 #65496] ERROR -- custom-bento-debian-85: /Library/Ruby/Gems/2.3.0/gems/test-kitchen-1.21.2/lib/kitchen/instance.rb:368:in `block in transition_to'
E, [2018-10-11T19:32:53.209606 #65496] ERROR -- custom-bento-debian-85: /Library/Ruby/Gems/2.3.0/gems/test-kitchen-1.21.2/lib/kitchen/instance.rb:367:in `each'
E, [2018-10-11T19:32:53.209626 #65496] ERROR -- custom-bento-debian-85: /Library/Ruby/Gems/2.3.0/gems/test-kitchen-1.21.2/lib/kitchen/instance.rb:367:in `transition_to'
E, [2018-10-11T19:32:53.209646 #65496] ERROR -- custom-bento-debian-85: /Library/Ruby/Gems/2.3.0/gems/test-kitchen-1.21.2/lib/kitchen/instance.rb:135:in `converge'
E, [2018-10-11T19:32:53.209666 #65496] ERROR -- custom-bento-debian-85: /Library/Ruby/Gems/2.3.0/gems/test-kitchen-1.21.2/lib/kitchen/command.rb:197:in `public_send'
E, [2018-10-11T19:32:53.209686 #65496] ERROR -- custom-bento-debian-85: /Library/Ruby/Gems/2.3.0/gems/test-kitchen-1.21.2/lib/kitchen/command.rb:197:in `run_action_in_thread'
E, [2018-10-11T19:32:53.209706 #65496] ERROR -- custom-bento-debian-85: /Library/Ruby/Gems/2.3.0/gems/test-kitchen-1.21.2/lib/kitchen/command.rb:169:in `block (2 levels) in run_action'
E, [2018-10-11T19:32:53.209726 #65496] ERROR -- custom-bento-debian-85: ----End Backtrace-----
```