### PR TITLE
Alternate tox verifier

### DIFF
--- a/lib/kitchen/provisioner/install.erb
+++ b/lib/kitchen/provisioner/install.erb
@@ -39,8 +39,8 @@ then
   #{sudo('sh')} $BOOTSTRAP #{bootstrap_options}
 elif [ -z "${SALT_VERSION}" -a "#{salt_install}" = "pip" ]
 then
-  echo "Makesure setuptools is new enough"
-  #{sudo(salt_pip_bin)} install "setuptools>=30"
+  echo "Makesure setuptools and pip are new enough"
+#{sudo(salt_pip_bin)} install "setuptools>=30" "pip>=19.0"
   echo #{sudo(salt_pip_bin)} #{salt_pip_install_command} #{salt_pip_pkg}
   #{sudo(salt_pip_bin)} #{salt_pip_install_command} #{salt_pip_pkg}
 elif [ -z "${SALT_VERSION}" -a "#{salt_install}" = "apt" ]

--- a/lib/kitchen/verifier/salttox.rb
+++ b/lib/kitchen/verifier/salttox.rb
@@ -27,10 +27,10 @@ module Kitchen
           ENV['KITCHEN_TESTS'].split(' ').each{|test| config[:tests].push(test)}
         end
         command = [
-	  'tox -c',
-	  File.join(root_path, config[:testingdir], 'tox.ini'),
-	  "-e #{instance.suite.name}",
-	  '--',
+          'tox -c',
+          File.join(root_path, config[:testingdir], 'tox.ini'),
+          "-e #{instance.suite.name}",
+          '--',
           '--sysinfo',
           '--output-columns=80',
           (config[:windows] ? "--names-file=#{root_path}\\testing\\tests\\whitelist.txt" : ''),

--- a/lib/kitchen/verifier/tox.rb
+++ b/lib/kitchen/verifier/tox.rb
@@ -1,0 +1,119 @@
+# -*- encoding: utf-8 -*-
+
+require "kitchen/verifier/base"
+
+module Kitchen
+  module Verifier
+    class Tox < Kitchen::Verifier::Base
+      kitchen_verifier_api_version 1
+
+      plugin_version Kitchen::VERSION
+
+      # Opts that carry on
+      default_config :testingdir, '/testing'
+      default_config :tests, []
+      default_config :transport, false
+      default_config :save, {}
+      default_config :windows, false
+
+      # Deprecated Opts
+      default_config :verbose, false
+      default_config :run_destructive, false
+      default_config :xml, false
+      default_config :coverage_xml, false
+      default_config :types, []
+
+      # New opts
+      default_config :pytest, false
+      default_config :coverage, false
+      default_config :junitxml, false
+      default_config :passthrough_opts, []
+
+      def call(state)
+        info("[#{name}] Verify on instance #{instance.name} with state=#{state}")
+        root_path = (config[:windows] ? '%TEMP%\\kitchen' : '/tmp/kitchen')
+        if ENV['KITCHEN_TESTS']
+          ENV['KITCHEN_TESTS'].split(' ').each{|test| config[:tests].push(test)}
+        end
+        toxenv = instance.suite.name
+        if config[:pytest]
+          toxenv = "#{toxenv}-pytest"
+        else
+          toxenv = "#{toxenv}-runtests"
+        end
+        if config[:coverage]
+          toxenv = "#{toxenv}-coverage"
+        end
+
+        if config[:junitxml]
+          junitxml = File.join(root_path, config[:testingdir], 'artifacts', 'xml-unittests-output')
+          if config[:pytest]
+            junitxml = "--junitxml=#{File.join(junitxml, 'test-results.xml')}"
+          else
+            junitxml = "--xml=#{junitxml}"
+          end
+        end
+
+        # Be sure to copy the remote artifacts directory to the local machine
+        config[:save][File.join(root_path, config[:testingdir], 'artifacts')] = 'artifacts'
+
+        command = [
+          'tox -c',
+          File.join(root_path, config[:testingdir], 'tox.ini'),
+          "-e #{toxenv}",
+          '--',
+          '--sysinfo',
+          '--output-columns=120',
+          (config[:junitxml] ? junitxml : ''),
+          (config[:windows] ? "--names-file=#{root_path}\\testing\\tests\\whitelist.txt" : ''),
+          (config[:transport] ? "--transport=#{config[:transport]}" : ''),
+          (config[:verbose] ? '-v' : ''),
+          (config[:run_destructive] ? "--run-destructive" : ''),
+          config[:passthrough_opts].join(' '),
+          config[:tests].join(' '),
+          '2>&1',
+        ].join(' ')
+        if config[:windows]
+           command = "cmd.exe /c \"#{command}\" 2>&1"
+        end
+        info("Running Command: #{command}")
+        instance.transport.connection(state) do |conn|
+          begin
+            if config[:windows]
+              conn.execute('$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")')
+              conn.execute("$env:PythonPath = [Environment]::ExpandEnvironmentVariables(\"#{root_path}\\testing\")")
+            else
+              begin
+                conn.execute(sudo("chown -R $USER #{root_path}"))
+              rescue => e
+                error("Failed to chown #{root_path} :: #{e}")
+              end
+            end
+            begin
+              conn.execute(sudo(command))
+            rescue => e
+              info("Verify command failed :: #{e}")
+            end
+          ensure
+            config[:save].each do |remote, local|
+              unless config[:windows]
+                begin
+                  conn.execute(sudo("chmod -R +r #{remote}"))
+                rescue => e
+                  error("Failed to chown #{remote} :: #{e}")
+                end
+              end
+              begin
+                info("Copying #{remote} to #{local}")
+                conn.download(remote, local)
+              rescue => e
+                error("Failed to copy #{remote} to #{local} :: ${e}")
+              end
+            end
+          end
+        end
+        debug("[#{name}] Verify completed.")
+      end
+    end
+  end
+end

--- a/lib/kitchen/verifier/tox.rb
+++ b/lib/kitchen/verifier/tox.rb
@@ -15,6 +15,7 @@ module Kitchen
       default_config :transport, false
       default_config :save, {}
       default_config :windows, false
+      default_config :verbose, false
       default_config :run_destructive, false
 
       # New opts
@@ -71,7 +72,7 @@ module Kitchen
           (config[:junitxml] ? junitxml : ''),
           (config[:windows] ? "--names-file=#{root_path}\\testing\\tests\\whitelist.txt" : ''),
           (config[:transport] ? "--transport=#{config[:transport]}" : ''),
-          (config[:verbose] ? '-v' : ''),
+          (config[:verbose] ? '-vv' : '-v'),
           (config[:run_destructive] ? "--run-destructive" : ''),
           config[:passthrough_opts].join(' '),
           (config[:from_filenames].any? ? "--from-filenames=#{config[:from_filenames].join(',')}" : ''),

--- a/lib/kitchen/verifier/tox.rb
+++ b/lib/kitchen/verifier/tox.rb
@@ -9,7 +9,6 @@ module Kitchen
 
       plugin_version Kitchen::VERSION
 
-      # Opts that carry on
       default_config :testingdir, '/testing'
       default_config :tests, []
       default_config :transport, false
@@ -17,6 +16,8 @@ module Kitchen
       default_config :windows, false
       default_config :verbose, false
       default_config :run_destructive, false
+      default_config :ssh_tests, true
+      default_config :proxy_tests, false
 
       # New opts
       default_config :pytest, false
@@ -42,8 +43,9 @@ module Kitchen
           # Right now PyTest runs don't support --from-filenames, just runtests
           if config[:enable_filenames] and ENV['CHANGE_TARGET'] and ENV['BRANCH_NAME']
             require 'git'
-            repo = Git.open('.')
-            config[:from_filenames] = repo.diff("origin/#{ENV['CHANGE_TARGET']}", "origin/#{ENV['BRANCH_NAME']}").name_status.keys.select{|file| file.end_with?('.py')}
+            repo = Git.open(Dir.pwd)
+            config[:from_filenames] = repo.diff("origin/#{ENV['CHANGE_TARGET']}",
+                                                "origin/#{ENV['BRANCH_NAME']}").name_status.keys.select{|file| file.end_with?('.py')}
           end
         end
         if config[:coverage]
@@ -79,6 +81,8 @@ module Kitchen
           (config[:transport] ? "--transport=#{config[:transport]}" : ''),
           (config[:verbose] ? '-vv' : '-v'),
           (config[:run_destructive] ? "--run-destructive" : ''),
+          (config[:ssh_tests] ? "--ssh-tests" : ''),
+          (config[:proxy_tests] ? "--proxy-tests" : ''),
           config[:passthrough_opts].join(' '),
           (config[:from_filenames].any? ? "--from-filenames=#{config[:from_filenames].join(',')}" : ''),
           tests,

--- a/lib/kitchen/verifier/tox.rb
+++ b/lib/kitchen/verifier/tox.rb
@@ -18,14 +18,14 @@ module Kitchen
       default_config :run_destructive, false
       default_config :ssh_tests, true
       default_config :proxy_tests, false
-
-      # New opts
       default_config :pytest, false
       default_config :coverage, false
       default_config :junitxml, false
       default_config :from_filenames, []
       default_config :enable_filenames, false
       default_config :passthrough_opts, []
+      default_config :output_columns, 120
+      default_config :sysinfo, true
 
       def call(state)
         info("[#{name}] Verify on instance #{instance.name} with state=#{state}")
@@ -74,8 +74,8 @@ module Kitchen
           File.join(root_path, config[:testingdir], 'tox.ini'),
           "-e #{toxenv}",
           '--',
-          '--sysinfo',
-          '--output-columns=120',
+          "--output-columns=#{config[:output_columns]}",
+          (config[:sysinfo] ? '--sysinfo' : ''),
           (config[:junitxml] ? junitxml : ''),
           (config[:windows] ? "--names-file=#{root_path}\\testing\\tests\\whitelist.txt" : ''),
           (config[:transport] ? "--transport=#{config[:transport]}" : ''),

--- a/lib/kitchen/verifier/tox.rb
+++ b/lib/kitchen/verifier/tox.rb
@@ -40,16 +40,16 @@ module Kitchen
         else
           toxenv = "#{toxenv}-runtests"
           tests = config[:tests].collect{|test| "-n #{test}"}.join(' ')
-          # Right now PyTest runs don't support --from-filenames, just runtests
-          if config[:enable_filenames] and ENV['CHANGE_TARGET'] and ENV['BRANCH_NAME']
-            require 'git'
-            repo = Git.open(Dir.pwd)
-            config[:from_filenames] = repo.diff("origin/#{ENV['CHANGE_TARGET']}",
-                                                "origin/#{ENV['BRANCH_NAME']}").name_status.keys.select{|file| file.end_with?('.py')}
-          end
         end
         if config[:coverage]
           toxenv = "#{toxenv}-coverage"
+        end
+
+        if config[:enable_filenames] and ENV['CHANGE_TARGET'] and ENV['BRANCH_NAME']
+          require 'git'
+          repo = Git.open(Dir.pwd)
+          config[:from_filenames] = repo.diff("origin/#{ENV['CHANGE_TARGET']}",
+                                              "origin/#{ENV['BRANCH_NAME']}").name_status.keys.select{|file| file.end_with?('.py')}
         end
 
         if config[:junitxml]

--- a/lib/kitchen/verifier/tox.rb
+++ b/lib/kitchen/verifier/tox.rb
@@ -60,7 +60,7 @@ module Kitchen
         end
 
         # Be sure to copy the remote artifacts directory to the local machine
-        config[:save]["#{File.join(root_path, config[:testingdir], 'artifacts')}/"] = 'artifacts'
+        config[:save]["#{File.join(root_path, config[:testingdir], 'artifacts')}"] = "#{Dir.pwd}/"
 
         command = [
           'tox -c',

--- a/lib/kitchen/verifier/tox.rb
+++ b/lib/kitchen/verifier/tox.rb
@@ -60,7 +60,7 @@ module Kitchen
         end
 
         # Be sure to copy the remote artifacts directory to the local machine
-        config[:save][File.join(root_path, config[:testingdir], 'artifacts')] = 'artifacts'
+        config[:save]["#{File.join(root_path, config[:testingdir], 'artifacts')}/"] = 'artifacts'
 
         command = [
           'tox -c',

--- a/lib/kitchen/verifier/tox.rb
+++ b/lib/kitchen/verifier/tox.rb
@@ -60,7 +60,12 @@ module Kitchen
         end
 
         # Be sure to copy the remote artifacts directory to the local machine
-        config[:save]["#{File.join(root_path, config[:testingdir], 'artifacts')}"] = "#{Dir.pwd}/"
+        save = {
+          "#{File.join(root_path, config[:testingdir], 'artifacts')}" => "#{Dir.pwd}/"
+        }
+        # Hash insert order matters, that's why we define a new one and merge
+        # the one from config
+        save.merge!(config[:save])
 
         command = [
           'tox -c',
@@ -101,7 +106,7 @@ module Kitchen
               info("Verify command failed :: #{e}")
             end
           ensure
-            config[:save].each do |remote, local|
+            save.each do |remote, local|
               unless config[:windows]
                 begin
                   conn.execute(sudo("chmod -R +r #{remote}"))


### PR DESCRIPTION
This tox verifier will allow running both pytest and runtests using tox.

The work on the salt branches hasn't been merged yet.

https://github.com/s0undt3ch/salt/tree/features/tox-runtests
https://github.com/s0undt3ch/salt/tree/features/tox-runtests-2018.3
https://github.com/s0undt3ch/salt/tree/features/tox-runtests-2019.2
https://github.com/s0undt3ch/salt/tree/features/tox-runtests-develop