### PR TITLE
Update examples showing platform-specific options

### DIFF
--- a/docs/provisioner_options.md
+++ b/docs/provisioner_options.md
@@ -354,18 +354,20 @@ Details on the various options available at the [salt-bootstrap](https://docs.sa
 
 For the Windows Powershell script:
 
-    platform:
+    platforms:
       - name: windows
-        salt_bootstrap_script: https://github.com/saltstack/salt-bootstrap/blob/develop/bootstrap-salt.ps1
-        salt_bootstrap_options: -version 2017.7.2
+        provisioner:
+          salt_bootstrap_script: https://github.com/saltstack/salt-bootstrap/blob/develop/bootstrap-salt.ps1
+          salt_bootstrap_options: -version 2017.7.2
 
 You can also use `%s` in any part of this, to replace with the version of salt, as specified by `salt_version`
 
 For example, below is a custom bootstrap option for centos6 requiring python2.7, here `%s` gets replaced by `2018.3`
 
-    platform:
+    platforms:
       - centos-6:
-        salt_bootstrap_options: "-P -p git -p curl -p sudo -y -x python2.7 git %s"
+        provisioner:
+          salt_bootstrap_options: "-P -p git -p curl -p sudo -y -x python2.7 git %s"
 
     suites:
       - name: oxygen


### PR DESCRIPTION
- list `platforms:` instead of `platform:`
- add the `provisioner:` element before kitchen-salt configuration items