### PR TITLE
Add salt_call_command

### DIFF
--- a/docs/provisioner_options.md
+++ b/docs/provisioner_options.md
@@ -488,6 +488,13 @@ default: `true`
 
 Install chef.  This is required by the busser to run tests, if no verification driver is specified in the `.kitchen.yml`
 
+### salt_call_command ###
+
+default for Windows: `c:\salt\salt-call.bat`
+default for others: `salt-call`
+
+Command used to invoke `salt-call`.
+
 ### salt_config ###
 
 default: `/etc/salt`

--- a/lib/kitchen-salt/util.rb
+++ b/lib/kitchen-salt/util.rb
@@ -55,6 +55,12 @@ module Kitchen
         end
       end
 
+      def salt_call
+        return config[:salt_call_command] if config[:salt_call_command]
+        return 'c:\\salt\\salt-call.bat' if windows_os?
+        'salt-call'
+      end
+
       def write_raw_file(name, contents)
         FileUtils.mkdir_p(File.dirname(name))
         File.open(name, 'wb') do |file|

--- a/lib/kitchen/provisioner/install.erb
+++ b/lib/kitchen/provisioner/install.erb
@@ -24,7 +24,7 @@ sh -c '
 #{Util.shell_helpers}
 
 # what version of salt is installed?
-command -v salt-call >/dev/null 2>&1 && SALT_VERSION=$(salt-call --version|cut -d " " -f 2)
+command -v #{salt_call} >/dev/null 2>&1 && SALT_VERSION=$(#{salt_call} --version|cut -d " " -f 2)
 command -v locale-gen >/dev/null 2>&1 && #{sudo('locale-gen')} en_US.UTF-8
 set +x
 export DEBIAN_FRONTEND=noninteractive
@@ -98,7 +98,7 @@ EOL
 fi
 
 # check again, now that an install of some form should have happened
-command -v salt-call >/dev/null 2>&1 && FULL_SALT_VERSION=$(salt-call --version|cut -d " " -f 2)
+command -v #{salt_call} >/dev/null 2>&1 && FULL_SALT_VERSION=$(#{salt_call} --version|cut -d " " -f 2)
 
 # extract short format of Salt version
 if [ ! -z "${FULL_SALT_VERSION}" ]

--- a/lib/kitchen/provisioner/install_win.erb
+++ b/lib/kitchen/provisioner/install_win.erb
@@ -5,8 +5,8 @@ bootstrap_options = config[:salt_bootstrap_options]
 salt_version = config[:salt_version]
 
 <<-POWERSHELL
-if (Test-Path c:\\salt\\salt-call.bat) {
-  $installed_version = $(c:\\salt\\salt-call.bat --version).split(' ')[1] 
+if (Test-Path #{salt_call}) {
+  $installed_version = $(#{salt_call} --version).split(' ')[1]
 }
 if (-Not $(Test-Path c:\\temp)) {
   New-Item -Path c:\\temp -itemtype directory
@@ -15,7 +15,7 @@ if (-Not $installed_version -And "#{salt_install}" -eq "bootstrap") {
   (New-Object net.webclient).DownloadFile("#{salt_url}", "c:\\temp\\salt_bootstrap.ps1")
   #{sudo('powershell')} c:\\temp\\salt_bootstrap.ps1 #{bootstrap_options}
 }
-$FULL_SALT_VERSION = $(c:\\salt\\salt-call.bat --version).split(' ')[1]
+$FULL_SALT_VERSION = $(#{salt_call} --version).split(' ')[1]
 if ($FULL_SALT_VERSION) {
   $YEAR = $FULL_SALT_VERSION.split('.')[0]
   $MONTH = $FULL_SALT_VERSION.split('.')[1]

--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -258,7 +258,6 @@ module Kitchen
 
         cmd = ''
         if windows_os?
-          salt_call = "c:\\salt\\salt-call.bat"
           salt_config_path = config[:salt_config]
           cmd << "(get-content #{os_join(config[:root_path], salt_config_path, 'minion')}) -replace '\\$env:TEMP', $env:TEMP | set-content #{os_join(config[:root_path], salt_config_path, 'minion')} ;"
         else
@@ -267,7 +266,6 @@ module Kitchen
           cmd << sudo("#{config[:root_path]}/dependencies.sh;")
           cmd << sudo("#{config[:root_path]}/gpgkey.sh;")
           salt_config_path = config[:salt_config]
-          salt_call = 'salt-call'
         end
         cmd << sudo("#{salt_call} --state-output=changes --config-dir=#{os_join(config[:root_path], salt_config_path)} state.highstate")
         cmd << " --log-level=#{config[:log_level]}" if config[:log_level]
@@ -453,7 +451,6 @@ module Kitchen
         instance_variables.each {|var| hash[var[1..-1]] = instance_variable_get(var) }
         hash.map{|k,v| [k.to_s.to_sym,v]}.to_h
       end
-
     end
   end
 end


### PR DESCRIPTION
Add a new `salt_call_command` option. This allows using salt when it's installed outside the normal OS paths, such as when installed to `/opt/salt/bin` on macOS.