### PR TITLE
Fixes for Windows

### DIFF
--- a/lib/kitchen/provisioner/install_win.erb
+++ b/lib/kitchen/provisioner/install_win.erb
@@ -2,7 +2,7 @@
 salt_install = config[:salt_install]
 salt_url = config[:salt_bootstrap_url]
 salt_version = config[:salt_version]
-bootstrap_options = config[:salt_bootstrap_options].gsub(/%s/, salt_version)
+bootstrap_options = config[:salt_bootstrap_options] % [salt_version]
 
 <<-POWERSHELL
 if (Test-Path #{salt_call}) {

--- a/lib/kitchen/provisioner/install_win.erb
+++ b/lib/kitchen/provisioner/install_win.erb
@@ -1,8 +1,8 @@
 <%=
 salt_install = config[:salt_install]
 salt_url = config[:salt_bootstrap_url]
-bootstrap_options = config[:salt_bootstrap_options]
 salt_version = config[:salt_version]
+bootstrap_options = config[:salt_bootstrap_options].gsub(/%s/, salt_version)
 
 <<-POWERSHELL
 if (Test-Path c:\\salt\\salt-call.bat) {
@@ -12,6 +12,7 @@ if (-Not $(Test-Path c:\\temp)) {
   New-Item -Path c:\\temp -itemtype directory
 }
 if (-Not $installed_version -And "#{salt_install}" -eq "bootstrap") {
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
   (New-Object net.webclient).DownloadFile("#{salt_url}", "c:\\temp\\salt_bootstrap.ps1")
   #{sudo('powershell')} c:\\temp\\salt_bootstrap.ps1 #{bootstrap_options}
 }


### PR DESCRIPTION
Use TLS 1.2 to download the bootstrap script. This is required to pull the default bootstrap script since (Powershell appears to use TLS 1.0 by default)[https://stackoverflow.com/a/49800855/792711].

Replace `%s` in `salt_bootstrap_options` with the salt version per the docs and to have parity with other OSes.