### PR TITLE
Ignore HostKey for git clone

### DIFF
--- a/lib/kitchen/provisioner/formula-fetch.sh
+++ b/lib/kitchen/provisioner/formula-fetch.sh
@@ -47,7 +47,7 @@ function fetchGitFormula() {
               popd &>/dev/null
           else
               echo "git clone $source $GIT_FORMULAS_PATH/$name -b $branch"
-              git clone "$source" "$GIT_FORMULAS_PATH/$name" -b "$branch"
+              GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone "$source" "$GIT_FORMULAS_PATH/$name" -b "$branch"
           fi
           # install dependencies
           FETCHED+=($name)


### PR DESCRIPTION
Fixes #276

With the fix

>        Install External Dependencies
>       Fetching: apt
>      git clone git@gitlab.cozycloud.cc:salt/formulas-apt.git /usr/share/salt-formulas/env/_formulas/apt -b master
>       Cloning into '/usr/share/salt-formulas/env/_formulas/apt'...
>      Warning: Permanently added 'gitlab.company.cc,163.234.234.123' (ECDSA) to the list of known hosts.
