### PR TITLE
bump version to v0.6.0

### DIFF
--- a/kitchen-salt.gemspec
+++ b/kitchen-salt.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.rubyforge_project = '[none]'
 
   spec.add_runtime_dependency 'hashie', '>= 3.5'
-  spec.add_runtime_dependency 'test-kitchen', '~> 1.4'
+  spec.add_runtime_dependency 'test-kitchen', '>= 1.4'
 
   spec.add_development_dependency 'coderay'
   spec.add_development_dependency 'gem-release', '~> 0.7.3'

--- a/lib/kitchen-salt/version.rb
+++ b/lib/kitchen-salt/version.rb
@@ -1,5 +1,5 @@
 module Kitchen
   module Salt
-    VERSION = '0.5.0'.freeze
+    VERSION = '0.6.0'.freeze
   end
 end


### PR DESCRIPTION
also allow for test-kitchen 2.0.0 to be installed.