### PR TITLE
new pre_salt_command

### DIFF
--- a/docs/provisioner_options.md
+++ b/docs/provisioner_options.md
@@ -484,6 +484,12 @@ default: `https://www.chef.io/chef/install.sh`
 
 The chef bootstrap installer, used to provide Ruby for the serverspec test runner on the guest OS.
 
+### pre_salt_command ###
+
+default: nil
+
+Run any command just before running salt_command.
+
 ### require_chef ###
 
 default: `true`

--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -268,6 +268,10 @@ module Kitchen
           cmd << sudo("#{config[:root_path]}/gpgkey.sh;") if config[:gpg_key]
           salt_config_path = config[:salt_config]
         end
+
+        if config[:pre_salt_command]
+          cmd << "#{config[:pre_salt_command]};"
+        end
         cmd << sudo("#{salt_call} --state-output=changes --config-dir=#{os_join(config[:root_path], salt_config_path)} state.highstate")
         cmd << " --log-level=#{config[:log_level]}" if config[:log_level]
         cmd << " --id=#{config[:salt_minion_id]}" if config[:salt_minion_id]


### PR DESCRIPTION
Hello,

this is an intent to solve #295 implementing a new directive `pre_salt_command` which lets the user define a command to run just before `salt-call` but after salt installation and files copying.

I'm not fluent in Ruby dev so this is my raw intent but it may need some advices for a better implementation or adding tests.