### PR TITLE
Make pre_salt_command failure stop the converge

### DIFF
--- a/docs/provisioner_options.md
+++ b/docs/provisioner_options.md
@@ -488,7 +488,7 @@ The chef bootstrap installer, used to provide Ruby for the serverspec test runne
 
 default: nil
 
-Run any command just before running salt_command.
+Run any command just before running salt_command. If not successful, execution stops.
 
 ### require_chef ###
 

--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -270,7 +270,7 @@ module Kitchen
         end
 
         if config[:pre_salt_command]
-          cmd << "#{config[:pre_salt_command]};"
+          cmd << "#{config[:pre_salt_command]} && "
         end
         cmd << sudo("#{salt_call} --state-output=changes --config-dir=#{os_join(config[:root_path], salt_config_path)} state.highstate")
         cmd << " --log-level=#{config[:log_level]}" if config[:log_level]


### PR DESCRIPTION
Hello,

the new `pre_salt_command` (introduced on #297) helps to run a command before the highstate/salt-call. In my use case, it's used to download needed formulas. 
This means that if the pre command fails running the salt-call is useless _(because it will fail)_.

This PR changes just how the `pre_salt_command` and the `salt-call` are run one after the other, making the second not run if the first has failed.
I tested it and it makes the Kitchen `converge` step fail.
