### PR TITLE
Fail fast on Windows when setting up dependency scripts

### DIFF
--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -408,6 +408,13 @@ module Kitchen
       end
 
       def prepare_dependencies
+        # Dependency scripts are bash scripts only
+        # Copying them clobbers the kitchen temp directory
+        # with a file named `kitchen`. If adding Windows
+        # support for dependencies, relocate into a
+        # sub-directory
+        return if windows_os?
+
         # upload scripts
         sandbox_scripts_path = File.join(sandbox_path, config[:salt_config], 'scripts')
         info("Preparing scripts into #{config[:salt_config]}/scripts")


### PR DESCRIPTION
Fixes #296.

Digging into this, it appears winrm-fs extracts files in the root of the sandbox as a file named `kitchen`, thereby preventing creation of a directory named `kitchen`. I'm struggling to parse the winrm-fs gem's code to figure out why the files extract this way, and since dependencies are bash-only and skipped on Windows, simply bypassing the dependency file creation on Windows fixes this issue.