### PR TITLE
Minor Fixes to the salt solo provisioner and the nox verifier

### DIFF
--- a/docs/provisioner_options.md
+++ b/docs/provisioner_options.md
@@ -315,7 +315,7 @@ Method by which salt will be installed:
 - **apt**: install salt from an apt repository.
 - **distrib**: install the version of salt that comes with the distribution.
 - **ppa**: install salt from a ppa.
-- **none**: bypass salt installation.
+- **false**: bypass salt installation.
 
 Except for `distrib` and `bootstrap`, most of these options will require extra configuration to make sure it fits the tests distribution version.  Unless the newest version is used, then it should just work for yum and apt setups.
 

--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -106,7 +106,7 @@ module Kitchen
       end
 
       def install_command
-        unless config[:salt_install] == 'pip' || config[:install_after_init_environment]
+        unless not config[:salt_install] || config[:salt_install] == 'pip' || config[:install_after_init_environment]
           setup_salt
         end
       end

--- a/lib/kitchen/verifier/nox.rb
+++ b/lib/kitchen/verifier/nox.rb
@@ -17,7 +17,7 @@ module Kitchen
       default_config :windows, nil
       default_config :verbose, false
       default_config :run_destructive, false
-      default_config :pytest, false
+      default_config :runtests, false
       default_config :coverage, false
       default_config :junitxml, false
       default_config :from_filenames, []
@@ -73,12 +73,14 @@ module Kitchen
 
         if ENV['NOX_ENV_NAME']
           noxenv = ENV['NOX_ENV_NAME']
-        else
-          # Default to runtests-zeromq
+        elsif config[:runtests] == true
           noxenv = "runtests-zeromq"
+        else
+          # Default to pytest-zeromq
+          noxenv = "pytest-zeromq"
         end
 
-        # Is the nox env alreay including the Python version?
+        # Is the nox env already including the Python version?
         if not noxenv.match(/^(.*)-([\d]{1})(\.([\d]{1}))?$/)
           # Nox env's are not py<python-version> named, they just use the <python-version>
           # Additionally, nox envs are parametrised to enable or disable test coverage


### PR DESCRIPTION
* Allow to actually bypass installing salt and run its installed checks
* Default to the pytest nox sessions