### PR TITLE
Fix bug #306 with too strict install_salt check

### DIFF
--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -108,7 +108,7 @@ module Kitchen
 
       def install_command
         return unless config[:salt_install]
-        unless not config[:salt_install] == 'pip' || config[:install_after_init_environment]
+        unless config[:salt_install] == 'pip' || config[:install_after_init_environment]
           setup_salt
         end
       end


### PR DESCRIPTION
Fix #306. I think the idea was to not return `setup_salt` when using pip or installing after init.

_Could also be written `if not` but rubyists like `unless` :)_