### PR TITLE
Fix the build for ubuntu 16.04 and 18.04

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -75,7 +75,7 @@ platforms:
     driver:
       run_command: '/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes -o PidFile=/tmp/sshd.pid'
     provisioner:
-      salt_apt_repo: 'https://repo.saltstack.com/apt/ubuntu/18.04/amd64/'
+      salt_apt_repo: 'https://repo.saltstack.com/apt/ubuntu/18.04/amd64'
       salt_apt_repo_key: 'https://repo.saltstack.com/apt/ubuntu/18.04/amd64/latest/SALTSTACK-GPG-KEY.pub'
       init_environment: |
         sudo mkdir -p /tmp/kitchen/var/cache/salt/master

--- a/lib/kitchen/provisioner/salt_solo.rb
+++ b/lib/kitchen/provisioner/salt_solo.rb
@@ -56,7 +56,7 @@ module Kitchen
         remote_states: nil,
         require_chef: true,
         salt_apt_repo_key: 'https://repo.saltstack.com/apt/ubuntu/16.04/amd64/latest/SALTSTACK-GPG-KEY.pub',
-        salt_apt_repo: 'https://repo.saltstack.com/apt/ubuntu/16.04/amd64/',
+        salt_apt_repo: 'https://repo.saltstack.com/apt/ubuntu/16.04/amd64',
         salt_bootstrap_options: '',
         salt_bootstrap_url: 'https://bootstrap.saltstack.com',
         salt_config: '/etc/salt',


### PR DESCRIPTION
The Travis build is failing on ubuntu 16.04 and 18.04 because the urls:
- `https://repo.saltstack.com/apt/ubuntu/16.04/amd64//latest`
- `https://repo.saltstack.com/apt/ubuntu/18.04/amd64//latest`
contain double slashes that lead to an 404 error.

I'm not sure if this fixes it, but let's see what happens.


