### PR TITLE
Fix install.sh to account for new amazon format

### DIFF
--- a/assets/install.sh
+++ b/assets/install.sh
@@ -68,6 +68,7 @@ install_deps() {
     exit 1
   fi
 
+  echo "$(command -v ruby)"
   # make links to binaries
   mkdir -p /opt/chef/embedded/bin/
   [ ! -e /opt/chef/embedded/bin/gem ] && ln -s "$(command -v gem)" /opt/chef/embedded/bin/

--- a/assets/install.sh
+++ b/assets/install.sh
@@ -92,7 +92,7 @@ elif test -f "/etc/arch-release"; then
     platform="arch"
 elif test -f "/etc/system-release"; then
   platform="$(sed 's/^\(.\+\) release.\+/\1/' /etc/system-release | tr '[:upper:]' '[:lower:]')"
-  if test "$platform" = "amazon linux ami"; then
+  if test "$platform" = "amazon linux ami" || test "$platform" = "amazon linux"; then
     platform="redhat"
   fi
 elif test -f "etc/alpine-release"; then


### PR DESCRIPTION
Amazon changed the format of what is in `/etc/system-release`, such that the parsing logic now returns `amazon linux`. This falls through the `install_deps()` logic, causing the converge step to fail. Added additional `||` condition for just `amazon linux`.

Tested change by modifying `install.sh` inside default `amazonlinux:1` & `amazonlinux:2` containers, and executing it.