### PR TITLE
bugfix: Faulty logic check for state_collection config var

### DIFF
--- a/docs/provisioner_options.md
+++ b/docs/provisioner_options.md
@@ -22,7 +22,7 @@ Name of the formula directory for finding where the state files are located.
 
 ### state_collection ###
 
-default: `nil`
+default: `false`
 
 Directory containing salt states that is not a formula
 

--- a/lib/kitchen-salt/states.rb
+++ b/lib/kitchen-salt/states.rb
@@ -99,7 +99,7 @@ module Kitchen
 
         if config[:local_salt_root].nil?
           states_location = config[:kitchen_root]
-          unless config[:state_collection].nil?
+          if config[:state_collection]
             states_location = File.join(states_location, config[:state_collection])
           end
         else


### PR DESCRIPTION
`state_collection` defaults to `false`, not `nil` [[1](https://github.com/saltstack/kitchen-salt/blob/cf5c41bf92547a422ad7e6de5ef955e9d84404fa/lib/kitchen/provisioner/salt_solo.rb#L84)].

We were hitting an issue when testing out formulas where this code was being hit and producing errors like:
```
Failed to complete #converge action: [no implicit conversion of false into String] on default-debian-buster
```

This effectively broke our CI for formulas since the new release was cut ☹️ 